### PR TITLE
Issue #78 - remove the extensions info tab from properties dialog

### DIFF
--- a/src/main/java/ca/corbett/musicplayer/extensions/MusicPlayerExtensionManager.java
+++ b/src/main/java/ca/corbett/musicplayer/extensions/MusicPlayerExtensionManager.java
@@ -1,8 +1,6 @@
 package ca.corbett.musicplayer.extensions;
 
 import ca.corbett.extensions.ExtensionManager;
-import ca.corbett.extras.properties.AbstractProperty;
-import ca.corbett.extras.properties.LabelProperty;
 import ca.corbett.musicplayer.Actions;
 import ca.corbett.musicplayer.Version;
 import ca.corbett.musicplayer.audio.PlaylistUtil;
@@ -16,7 +14,6 @@ import ca.corbett.musicplayer.ui.TrackInfoDialog;
 import ca.corbett.musicplayer.ui.VisualizationManager;
 
 import javax.swing.filechooser.FileNameExtensionFilter;
-import java.awt.Font;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.util.ArrayList;
@@ -84,29 +81,6 @@ public class MusicPlayerExtensionManager extends ExtensionManager<MusicPlayerExt
     public void deactivateAll() {
         super.deactivateAll();
         logger.info("Extension manager: all extensions have been shut down.");
-    }
-
-    /**
-     * Overridden here so we can add a read-only view of the extension scan dir
-     * and some instructions for how to change the value. I want to add these instructions
-     * dead last so that they show up at the end of the properties dialog
-     * no matter how many extensions are loaded.
-     *
-     * @return A List of all properties exposed by all enabled extensions.
-     */
-    @Override
-    public List<AbstractProperty> getAllEnabledExtensionProperties() {
-        List<AbstractProperty> props = super.getAllEnabledExtensionProperties();
-
-        props.add(LabelProperty.createLabel("Extensions.Configuration.label1", "The following directory will be scanned for extension jars:"));
-        props.add(new LabelProperty("Extensions.Configuration.scanDir", Version.EXTENSIONS_DIR.getAbsolutePath(),
-                                    new Font(Font.MONOSPACED, Font.BOLD, 12)));
-        props.add(LabelProperty.createLabel("Extensions.Configuration.label2",
-                "<html>If the directory exists and is readable, it is scanned at startup<br>" +
-                    "automatically. You can set it using the following system property,<br>" +
-                    "but it requires an application restart!<br><br>" +
-                    "<pre>EXTENSIONS_DIR</pre></html>"));
-        return props;
     }
 
     /**

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -3,8 +3,9 @@ https://github.com/scorbo2/musicplayer
 Author: Steve Corbett
 
 Version 3.2 [2025-12-31] - Maintenance release
-  #74 Upgrade to swing-extras 2.6
+  #78 Remove "extensions" info tab from app properties dialog
   #76 Fix bug in reloadUI() with single instance logic
+  #74 Upgrade to swing-extras 2.6
 
 Version 3.1 [2025-12-20] - Maintenance release
   #73 Fix bug when opening files with spaces from command line


### PR DESCRIPTION
This PR removes an old informational tab from the application properties dialog. The information on that tab is arguably better presented in existing documentation elsewhere, so there's no need to feature it on the props dialog anymore.
