### PR TITLE
Issue #93 - upgrade to swing-extras 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.6.0</version>
+            <version>2.9.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/musicplayer/AppConfig.java
+++ b/src/main/java/ca/corbett/musicplayer/AppConfig.java
@@ -17,6 +17,7 @@ import ca.corbett.extras.properties.LabelProperty;
 import ca.corbett.extras.properties.PropertiesManager;
 import ca.corbett.extras.properties.ShortTextProperty;
 import ca.corbett.extras.properties.SliderProperty;
+import ca.corbett.extras.properties.dialog.PropertiesDialog;
 import ca.corbett.forms.fields.CheckBoxField;
 import ca.corbett.forms.fields.ComboField;
 import ca.corbett.forms.fields.ShortTextField;
@@ -31,8 +32,8 @@ import ca.corbett.musicplayer.ui.VisualizationThread;
 import ca.corbett.musicplayer.ui.VisualizationWindow;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Frame;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,6 +131,10 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
 
     protected AppConfig() {
         super(Version.FULL_NAME, PROPS_FILE, MusicPlayerExtensionManager.getInstance());
+
+        // Debatable, but I prefer the "classic" style props dialog for this application
+        // over the newer "action panel" style introduced in swing-extras 2.8:
+        setDialogType(DialogType.Classic);
     }
 
     /**
@@ -629,14 +634,13 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
      * and also so that we can set the initial state of certain fields based upon
      * the values of our properties.
      *
-     * @param owner The owning Frame (so we can make the dialog modal to that Frame).
-     * @return true if the user OK'd the dialog with changes.
+     * @param dialog the generated PropertiesDialog, before it is shown to the user.
      */
     @Override
-    public boolean showPropertiesDialog(Frame owner) {
+    protected void propertiesDialogCreated(PropertiesDialog dialog) {
         // We need a slightly larger dialog than the default value:
-        propertiesDialogMinimumWidth = propertiesDialogInitialWidth = 660;
-        propertiesDialogMinimumHeight = propertiesDialogInitialHeight = 480;
+        dialog.setSize(new Dimension(660, 480));
+        dialog.setMinimumSize(new Dimension(660, 480));
 
         // Set initial state of waveform fields based on the value of overrideAppThemeWaveform:
         boolean isWaveformOverride = overrideAppThemeWaveform.getSelectedIndex() == 1;
@@ -653,8 +657,6 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
         visualizerOverlayBorderColor.setInitiallyEditable(isOverlayOverride);
         visualizerOverlayProgressBackground.setInitiallyEditable(isOverlayOverride);
         visualizerOverlayProgressForeground.setInitiallyEditable(isOverlayOverride);
-
-        return super.showPropertiesDialog(owner);
     }
 
     /**

--- a/src/main/java/ca/corbett/musicplayer/AppConfig.java
+++ b/src/main/java/ca/corbett/musicplayer/AppConfig.java
@@ -630,7 +630,7 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
     }
 
     /**
-     * Overridden here so we can add override the default size of the properties dialog,
+     * Overridden here so we can customize the size of the properties dialog,
      * and also so that we can set the initial state of certain fields based upon
      * the values of our properties.
      *

--- a/src/main/java/ca/corbett/musicplayer/ui/CustomSortDialog.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/CustomSortDialog.java
@@ -1,6 +1,6 @@
 package ca.corbett.musicplayer.ui;
 
-import ca.corbett.extras.properties.PropertiesDialog;
+import ca.corbett.extras.ScrollUtil;
 import ca.corbett.forms.FormPanel;
 import ca.corbett.forms.fields.CheckBoxField;
 import ca.corbett.forms.fields.ComboField;
@@ -41,7 +41,7 @@ public class CustomSortDialog extends JDialog {
         setMinimumSize(new Dimension(380, 200));
         setModal(true);
         setLayout(new BorderLayout());
-        add(PropertiesDialog.buildScrollPane(buildFormPanel()), BorderLayout.CENTER);
+        add(ScrollUtil.buildScrollPane(buildFormPanel()), BorderLayout.CENTER);
         add(buildButtonPanel(), BorderLayout.SOUTH);
         restorePreviousSettings();
     }

--- a/src/main/java/ca/corbett/musicplayer/ui/TrackInfoDialog.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/TrackInfoDialog.java
@@ -1,6 +1,6 @@
 package ca.corbett.musicplayer.ui;
 
-import ca.corbett.extras.properties.PropertiesDialog;
+import ca.corbett.extras.ScrollUtil;
 import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
 import ca.corbett.forms.fields.LabelField;
@@ -44,7 +44,7 @@ public class TrackInfoDialog extends JFrame {
         formPanel.add(new LabelField("Album:", meta.getAlbum()));
         formPanel.add(new LabelField("Genre:", meta.getGenre()));
         formPanel.add(new LabelField("Length:", meta.getDurationFormatted()));
-        add(PropertiesDialog.buildScrollPane(formPanel), BorderLayout.CENTER);
+        add(ScrollUtil.buildScrollPane(formPanel), BorderLayout.CENTER);
     }
 
     protected static String trimString(String input) {

--- a/src/test/java/ca/corbett/musicplayer/ActionsTest.java
+++ b/src/test/java/ca/corbett/musicplayer/ActionsTest.java
@@ -67,7 +67,11 @@ class ActionsTest {
 
         @Override
         public AppExtensionInfo getInfo() {
-            return new AppExtensionInfo.Builder("someextension").build();
+            return new AppExtensionInfo.Builder("someextension")
+                .setTargetAppName(Version.NAME)
+                .setTargetAppVersion(Version.VERSION)
+                .setVersion(Version.VERSION)
+                .build();
         }
 
         @Override

--- a/src/test/java/ca/corbett/musicplayer/extensions/MusicPlayerExtensionManagerTest.java
+++ b/src/test/java/ca/corbett/musicplayer/extensions/MusicPlayerExtensionManagerTest.java
@@ -2,6 +2,7 @@ package ca.corbett.musicplayer.extensions;
 
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.musicplayer.Version;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -56,7 +57,11 @@ class MusicPlayerExtensionManagerTest {
 
         @Override
         public AppExtensionInfo getInfo() {
-            return new AppExtensionInfo.Builder("XmlPlay").build();
+            return new AppExtensionInfo.Builder("XmlPlay")
+                .setTargetAppName(Version.NAME)
+                .setTargetAppVersion(Version.VERSION)
+                .setVersion(Version.VERSION)
+                .build();
         }
 
         @Override

--- a/src/test/java/ca/corbett/musicplayer/ui/AppThemeTest.java
+++ b/src/test/java/ca/corbett/musicplayer/ui/AppThemeTest.java
@@ -2,6 +2,7 @@ package ca.corbett.musicplayer.ui;
 
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.musicplayer.Version;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtension;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtensionManager;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,11 @@ class AppThemeTest {
 
         @Override
         public AppExtensionInfo getInfo() {
-            return new AppExtensionInfo.Builder("textextension").build();
+            return new AppExtensionInfo.Builder("textextension")
+                .setTargetAppName(Version.NAME)
+                .setTargetAppVersion(Version.VERSION)
+                .setVersion(Version.VERSION)
+                .build();
         }
 
         @Override

--- a/src/test/java/ca/corbett/musicplayer/ui/AudioPanelIdleAnimationTest.java
+++ b/src/test/java/ca/corbett/musicplayer/ui/AudioPanelIdleAnimationTest.java
@@ -2,6 +2,7 @@ package ca.corbett.musicplayer.ui;
 
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.musicplayer.Version;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtension;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtensionManager;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,7 +58,11 @@ class AudioPanelIdleAnimationTest {
 
         @Override
         public AppExtensionInfo getInfo() {
-            return new AppExtensionInfo.Builder("CustomAnimations").build();
+            return new AppExtensionInfo.Builder("CustomAnimations")
+                .setTargetAppName(Version.NAME)
+                .setTargetAppVersion(Version.VERSION)
+                .setVersion(Version.VERSION)
+                .build();
         }
 
         @Override


### PR DESCRIPTION
This PR addresses issue #93 by upgrading the `swing-extras` dependency from `2.6` to the latest `2.9-SNAPSHOT` (will remove SNAPSHOT as soon as `2.9` is released, soon).

Specific changes that were identified for this upgrade:

- `AppExtensionInfo` instances must now pass basic validation, even for test extensions created in unit tests. They must specify, at a minimum: target application name, target application version, extension name, and extension version.
- The `buildScrollPane` utility method moved from `PropertiesDialog` to a new `ScrollUtil` utility class. Updated all references.
- A new application properties dialog type ("action panel") has been introduced as of swing-extras `2.8`, and is now the default optino. But, I prefer the older, "classic" style for this application, so I have updated the code in `AppConfig` to request the legacy style dialog.
- A new `propertiesDialogCreated()` notification method is now provided by `AppProperties`, so we no longer have to override `showPropertiesDialog` to make basic changes to the generated dialog. The old static size properties have been removed from that class as they are no longer necessary (we can now invoke `setSize()` or `setMinimumSize()` directly as needed).
