### PR TITLE
Issue #64 - remove old workaround

### DIFF
--- a/src/main/java/ca/corbett/musicplayer/AppConfig.java
+++ b/src/main/java/ca/corbett/musicplayer/AppConfig.java
@@ -20,7 +20,6 @@ import ca.corbett.extras.properties.SliderProperty;
 import ca.corbett.extras.properties.dialog.PropertiesDialog;
 import ca.corbett.forms.fields.CheckBoxField;
 import ca.corbett.forms.fields.ComboField;
-import ca.corbett.forms.fields.ShortTextField;
 import ca.corbett.musicplayer.actions.ReloadUIAction;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtension;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtensionManager;
@@ -485,9 +484,6 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
                                                      "Playlist format:",
                                                      DEFAULT_FORMAT_STRING,
                                                      20);
-        playlistFormatString.addFormFieldGenerationListener(
-            (property, formField)
-                -> ((ShortTextField)formField).getTextField().setColumns(20)); // THIS SHOULD NOT BE NECESSARY!
         playlistFormatString.setHelpText(getPlaylistFormatCheatsheet());
 
         playlistCustomSortString = new ShortTextProperty("UI.Playlist.customFormatString", "customFormat", "");

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Author: Steve Corbett
 
 Version 3.3 [TODO release date goes here] - Maintenance release
   #87 AboutDialog was not showing application update information
+  #64 Remove old code workaround for this issue
 
 Version 3.2 [2025-12-31] - Maintenance release
   #84 SingleInstanceManager has moved to swing-extras 2.6

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -4,7 +4,7 @@ Author: Steve Corbett
 
 Version 3.3 [TODO release date goes here] - Maintenance release
   #87 AboutDialog was not showing application update information
-  #64 Remove old code workaround for this issue
+  #64 Remove old code workaround for this issue (no longer needed)
 
 Version 3.2 [2025-12-31] - Maintenance release
   #84 SingleInstanceManager has moved to swing-extras 2.6


### PR DESCRIPTION
This issue removes an old workaround that was added for issue #64. The issue has finally been solved and the workaround is no longer necessary. Tested in latest `3.3-SNAPSHOT` build and it works fine.