### PR TITLE
Issue #99 - make use of FallbackExceptionHandler, new in swing-extras

### DIFF
--- a/src/main/java/ca/corbett/musicplayer/Main.java
+++ b/src/main/java/ca/corbett/musicplayer/Main.java
@@ -55,7 +55,7 @@ public class Main {
         // Before we do anything else, set up logging:
         configureLogging();
 
-        // Set up a fallback exception handler so that unhandled exception get logged:
+        // Set up a fallback exception handler so that unhandled exceptions are logged:
         FallbackExceptionHandler.register();
 
         // Ensure only a single instance is running (if configured to do so):

--- a/src/main/java/ca/corbett/musicplayer/Main.java
+++ b/src/main/java/ca/corbett/musicplayer/Main.java
@@ -1,5 +1,6 @@
 package ca.corbett.musicplayer;
 
+import ca.corbett.extras.FallbackExceptionHandler;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.SingleInstanceManager;
 import ca.corbett.musicplayer.ui.MainWindow;
@@ -53,6 +54,9 @@ public class Main {
     public static void main(String[] args) {
         // Before we do anything else, set up logging:
         configureLogging();
+
+        // Set up a fallback exception handler so that unhandled exception get logged:
+        FallbackExceptionHandler.register();
 
         // Ensure only a single instance is running (if configured to do so):
         boolean isSingleInstanceEnabled = Boolean.parseBoolean(AppConfig.peek("UI.General.singleInstance"));

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -3,6 +3,7 @@ https://github.com/scorbo2/musicplayer
 Author: Steve Corbett
 
 Version 3.3 [TODO release date goes here] - Maintenance release
+  #99 Wire up a FallbackExceptionHandler
   #90 Use new StringFormatter utility method in swing-extras
   #87 AboutDialog was not showing application update information
   #64 Remove old code workaround for this issue (no longer needed)


### PR DESCRIPTION
This PR addresses issue #99 by wiring up a FallbackExceptionHandler (new in swing-extras `2.9`). This ensures that any uncaught exception will be properly logged.
