### PR TITLE
Issue #88 - add keyboard shortcuts for playlist removal

### DIFF
--- a/src/main/java/ca/corbett/musicplayer/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/MainWindow.java
@@ -17,6 +17,8 @@ import ca.corbett.musicplayer.actions.FullScreenStopAction;
 import ca.corbett.musicplayer.actions.NextAction;
 import ca.corbett.musicplayer.actions.PauseAction;
 import ca.corbett.musicplayer.actions.PlaylistOpenAction;
+import ca.corbett.musicplayer.actions.PlaylistRemoveAllAction;
+import ca.corbett.musicplayer.actions.PlaylistRemoveOneAction;
 import ca.corbett.musicplayer.actions.PlaylistSaveAction;
 import ca.corbett.musicplayer.actions.PrevAction;
 import ca.corbett.musicplayer.actions.ReloadUIAction;
@@ -482,6 +484,8 @@ public class MainWindow extends JFrame implements UIReloadable, AudioPanelListen
         keyStrokeManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+O"), new PlaylistOpenAction());
         keyStrokeManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+Q"), new ExitAction());
         keyStrokeManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+S"), new PlaylistSaveAction());
+        keyStrokeManager.registerHandler(KeyStrokeManager.parseKeyStroke("Del"), new PlaylistRemoveOneAction());
+        keyStrokeManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+Del"), new PlaylistRemoveAllAction());
 
         // Now register whatever AppConfig knows about (this includes extension-supplied KeyStrokes, if any):
         for (KeyStrokeProperty prop : AppConfig.getInstance().getKeyStrokeProperties()) {

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -6,6 +6,7 @@ Version 3.3 [TODO release date goes here] - Maintenance release
   #99 Wire up a FallbackExceptionHandler
   #98 Wire up a KeyStrokeManager (replaces old KeyboardManager)
   #90 Use new StringFormatter utility method in swing-extras
+  #88 Add playlist deletion keyboard shortcuts
   #87 AboutDialog was not showing application update information
   #64 Remove old code workaround for this issue (no longer needed)
 


### PR DESCRIPTION
This PR addresses issue #88 by adding a couple of new keyboard shortcuts:

- DEL: remove the currently selected playlist item, if any
- Ctrl+DEL: clear the playlist

