### PR TITLE
Issue 53 audio load

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Repository Summary
 
-**MusicPlayer** is a Java 17 music player with Swing UI featuring customizable visualizations and extension support via the [swing-extras](https://github.com/scorbo2/swing-extras) library. Built with Maven 3.9+, containing 53 Java files (~8,337 LOC), tested with JUnit 5. Main class: `ca.corbett.musicplayer.Main`.
+**MusicPlayer** is a Java 17 music player with Swing UI featuring customizable visualizations and extension support via the [swing-extras](https://github.com/scorbo2/swing-extras) library. Built with Maven 3.9+, tested with JUnit 5. Main class: `ca.corbett.musicplayer.Main`.
 
 ## Critical Build Requirements & Known Issues
 
@@ -39,11 +39,11 @@ Set environment variables `GITHUB_ACTOR` (your GitHub username) and `GITHUB_TOKE
 
 **Commands (run in order):**
 1. `mvn clean` - Clean project
-2. `mvn package` - Build + tests (~30-60s first run) → `target/musicplayer-3.0.jar` + `target/lib/`
+2. `mvn package` - Build + tests (~30-60s first run) → `target/musicplayer-<version>.jar` + `target/lib/`
 3. `mvn package -DskipTests` - Build without tests
 4. `mvn test` - Run tests only (6 test classes in `src/test/java/ca/corbett/musicplayer/`)
 
-**Run:** `cd target && java -jar musicplayer-3.0.jar` (requires display, not headless)
+**Run:** `cd target && java -jar musicplayer-<version>.jar` (requires display, not headless)
 
 **Optional:** If `~/bin/make-installer` exists on Linux, build auto-generates installer tarball (config: `installer.props`).
 
@@ -56,16 +56,19 @@ src/main/java/ca/corbett/musicplayer/
 ├── AppConfig.java          # Config (extends AppProperties from swing-extras)
 ├── Actions.java            # Media player and playlist commands (unrelated to the actions/ package)
 ├── actions/                # 18 UI action classes
-├── audio/                  # Audio playback, playlist (3 classes)
+├── audio/                  # Audio metadata, streaming playback helpers, waveform peak model
 ├── extensions/             # Extension system (MusicPlayerExtension, MusicPlayerExtensionManager, builtin/)
-└── ui/                     # 19 Swing components (MainWindow, AudioPanel, ControlPanel, Playlist, etc.)
+└── ui/                     # Swing components + async load/waveform worker threads
 ```
 
 **Architecture:**
 - **Extensions:** `swing-extras` ExtensionManager loads jars from `EXTENSIONS_DIR` (~/.MusicPlayer/extensions/)
 - **Config:** AppProperties auto-generates UI from properties in `AppConfig.java` → saved to `~/.MusicPlayer/MusicPlayer.props`
 - **Actions:** 18 Swing Actions in `actions/` - note that these are not related to `Actions.java` which is unrelated.
-- **Audio:** MP3 decoded via mp3spi → WAV → Java Sound API (see TODO in `AudioData.java`)
+- **Audio playback:** `AudioUtil.openPlaybackStream(...)` streams decoded PCM directly from source files (MP3/WAV) via Java Sound SPI.
+- **Audio loading:** `AudioLoadThread` performs lightweight metadata/file wrapper setup (`AudioData(File)`) only.
+- **Waveform generation:** `WaveformBuildThread` builds compact `WaveformPeaks` in the background; `AudioPanel` redraws progressively.
+- **Concurrency safety:** `AudioLoadCoordinator` serializes load requests and applies request-id stale checks to avoid outdated UI/playback updates during rapid next/prev activity.
 
 **Config Files:** `pom.xml` (Maven), `.editorconfig` (4-space indent, 120 char lines), `logging.properties`, `installer.props`
 
@@ -74,8 +77,6 @@ src/main/java/ca/corbett/musicplayer/
 **No CI/CD configured.** Manual validation: `mvn clean package` succeeds, tests pass, follow .editorconfig style.
 
 **Key Dependencies:** swing-extras (2.6.0), mp3spi (1.9.14), sqlite-jdbc (3.49.1.0), jackson (2.18.3), junit-jupiter (5.12.1)
-
-**Code Quality:** TODOs in AudioPanel, VisualizationThread, AudioData, AudioUtil. MP3→WAV conversion approach needs improvement (see AudioData.java).
 
 ## Development Tasks
 

--- a/installer.props
+++ b/installer.props
@@ -8,7 +8,7 @@ FORMAT="tarball"
 
 # Application name/version will also be used for the jar file name.
 APPLICATION="MusicPlayer"
-VERSION="3.2"
+VERSION="3.3-SNAPSHOT"
 
 # For proper categorization of our application icon in linux menus:
 CATEGORY="AudioVideo"

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,14 @@
 
     <build>
         <plugins>
+
+            <!-- Maven Surefire Plugin for running tests with JUnit 5 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/ca/corbett/musicplayer/Actions.java
+++ b/src/main/java/ca/corbett/musicplayer/Actions.java
@@ -142,10 +142,10 @@ public final class Actions {
         button.setContentAreaFilled(false);
         button.setFocusable(false);
         button.setPreferredSize(new Dimension(btnSize, btnSize));
+        button.setToolTipText(action.description);
         BufferedImage iconImage = MainWindow.loadIconResource(action.iconResource, iconSize, iconSize);
         ImageIcon icon = new ImageIcon(iconImage, action.description);
         button.setIcon(icon);
-        button.setToolTipText(action.description);
 
         return button;
     }

--- a/src/main/java/ca/corbett/musicplayer/AppConfig.java
+++ b/src/main/java/ca/corbett/musicplayer/AppConfig.java
@@ -14,10 +14,8 @@ import ca.corbett.extras.properties.EnumProperty;
 import ca.corbett.extras.properties.FontProperty;
 import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.extras.properties.KeyStrokeProperty;
-import ca.corbett.extras.properties.LabelProperty;
 import ca.corbett.extras.properties.PropertiesManager;
 import ca.corbett.extras.properties.ShortTextProperty;
-import ca.corbett.extras.properties.SliderProperty;
 import ca.corbett.extras.properties.dialog.PropertiesDialog;
 import ca.corbett.forms.fields.CheckBoxField;
 import ca.corbett.forms.fields.ComboField;
@@ -118,7 +116,6 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
     private ColorProperty visualizerOverlayProgressBackground;
     private ColorProperty visualizerOverlayProgressForeground;
     private ComboProperty<String> visualizerOldHardwareDelay;
-    private SliderProperty loadProgressBarShowDelayMS;
 
     /**
      * This is only used for setting default waveform prefs.
@@ -409,10 +406,6 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
         return visualizerScreensaverPrevention.getValue();
     }
 
-    public int getLoadProgressBarShowDelayMS() {
-        return loadProgressBarShowDelayMS.getValue();
-    }
-
     /**
      * Older or less capable graphics hardware needs 100-200 milliseconds to effect a
      * display mode switch (switching to fullscreen mode) - that means we sometimes
@@ -453,11 +446,6 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
                                                    "Only allow a single instance of MusicPlayer",
                                                    true);
 
-        LabelProperty label = new LabelProperty("UI.General.progressBarDelayMSLabel",
-                                                "Optional delay before showing the audio load progress bar:");
-        loadProgressBarShowDelayMS = new SliderProperty("UI.General.progressBarDelay", "", 0, 5000, 1000);
-        loadProgressBarShowDelayMS.setShouldExpand(false);
-        loadProgressBarShowDelayMS.setLabels(List.of("no delay", "1s", "2s", "3s", "4s", "5s"), false);
 
         // Make sure we respond to change events properly, to enable or disable the override fields:
         overrideAppThemeWaveform.addFormFieldChangeListener(event -> {
@@ -595,8 +583,6 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
                        controlAlignment,
                        idleAnimation,
                        enableSingleInstance,
-                       label,
-                       loadProgressBarShowDelayMS,
                        overrideAppThemeWaveform,
                        waveformBgColor,
                        waveformFillColor,

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
@@ -12,19 +12,14 @@ import java.util.logging.Logger;
 
 /**
  * A wrapper class to encapsulate a single audio clip.
- * Here, we track the original file, the converted file (if conversion was
- * done), the audio data associated with the clip, and metadata that we
- * managed to extract from the clip.
+ * The modern pipeline stores lightweight track metadata plus compact
+ * waveform peaks generated in the background.
+ *
+ * Legacy raw sample fields/methods are still present for compatibility,
+ * but they are no longer used by the active playback/rendering pipeline.
  * <p>
- * TODO I'm not happy with the wonky "convert from mp3 to wav and then play the wav" approach
- *      It's slow and monstrously memory unfriendly. Mostly I hate it because it's very slow,
- *      and results in a long gap of silence between tracks as the next track loads.
- *      But, without the raw wav data, I can't find a way to generate the audio waveform image,
- *      which is kind of a neat feature, and which also allows skipping forwards and backwards
- *      through the track by clicking on the waveform. Surely there's a middle of the road
- *      option where the application could have the best of both worlds - the speed of being
- *      able to stream audio directly from an mp3 file, while still being able to calculate
- *      a waveform image and allow clicking within it?
+ * TODO the remaining legacy raw-sample API can be removed in a future major
+ *      release once extension compatibility is no longer required.
  * </p>
  *
  * @author scorbo2
@@ -42,6 +37,7 @@ public class AudioData {
     private final int durationSeconds;
     private final WaveformPeaks waveformPeaks;
 
+    @Deprecated(since = "3.3", forRemoval = false)
     public AudioData(int[][] rawData, File sourceFile, float sampleRate) {
         this.rawData = rawData;
         this.sourceFile = sourceFile;
@@ -62,10 +58,12 @@ public class AudioData {
         this.waveformPeaks = new WaveformPeaks(2, this.sampleRate, 512);
     }
 
+    @Deprecated(since = "3.3", forRemoval = false)
     public int[][] getRawData() {
         return rawData;
     }
 
+    @Deprecated(since = "3.3", forRemoval = false)
     public float getSampleRate() {
         return sampleRate;
     }

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
@@ -9,6 +9,9 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
 
 /**
  * A wrapper class to encapsulate a single audio clip.
@@ -23,6 +26,9 @@ import java.util.logging.Logger;
 public class AudioData {
 
     private static final Logger logger = Logger.getLogger(AudioData.class.getName());
+    private static final int DEFAULT_WAVEFORM_CHANNELS = 2;
+    private static final float DEFAULT_WAVEFORM_SAMPLE_RATE = 44100f;
+    private static final int DEFAULT_WAVEFORM_FRAMES_PER_BUCKET = 512;
 
     private final File sourceFile;
     private BufferedImage waveformImage;
@@ -37,7 +43,25 @@ public class AudioData {
         this.sourceFile = sourceFile;
         this.metadata = AudioMetadata.fromFile(sourceFile);
         this.durationSeconds = Math.max(0, this.metadata.getDurationSeconds());
-        this.waveformPeaks = new WaveformPeaks(2, 44100f, 512);
+        this.waveformPeaks = createWaveformPeaks(sourceFile);
+    }
+
+    private static WaveformPeaks createWaveformPeaks(File sourceFile) {
+        try (AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(sourceFile)) {
+            AudioFormat format = audioInputStream.getFormat();
+            int channels = format.getChannels() > 0 ? format.getChannels() : DEFAULT_WAVEFORM_CHANNELS;
+            float sampleRate = format.getSampleRate() > 0 ? format.getSampleRate() : DEFAULT_WAVEFORM_SAMPLE_RATE;
+            return new WaveformPeaks(channels, sampleRate, DEFAULT_WAVEFORM_FRAMES_PER_BUCKET);
+        } catch (Exception ex) {
+            logger.log(Level.FINE,
+                    "Unable to determine audio format for waveform peak initialization, using defaults for "
+                            + sourceFile,
+                    ex);
+            return new WaveformPeaks(
+                    DEFAULT_WAVEFORM_CHANNELS,
+                    DEFAULT_WAVEFORM_SAMPLE_RATE,
+                    DEFAULT_WAVEFORM_FRAMES_PER_BUCKET);
+        }
     }
 
     public int getDurationSeconds() {

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
@@ -12,15 +12,10 @@ import java.util.logging.Logger;
 
 /**
  * A wrapper class to encapsulate a single audio clip.
- * The modern pipeline stores lightweight track metadata plus compact
- * waveform peaks generated in the background.
- *
- * Legacy raw sample fields/methods are still present for compatibility,
- * but they are no longer used by the active playback/rendering pipeline.
- * <p>
- * TODO the remaining legacy raw-sample API can be removed in a future major
- *      release once extension compatibility is no longer required.
- * </p>
+ * The current pipeline keeps this object lightweight:
+ * source file identity + parsed metadata + compact waveform peaks.
+ * Playback streams directly from the source file and waveform data is
+ * generated asynchronously by {@link ca.corbett.musicplayer.ui.WaveformBuildThread}.
  *
  * @author scorbo2
  * @since 2025-03-23
@@ -29,43 +24,20 @@ public class AudioData {
 
     private static final Logger logger = Logger.getLogger(AudioData.class.getName());
 
-    private final int[][] rawData;
     private final File sourceFile;
     private BufferedImage waveformImage;
     private AudioMetadata metadata;
-    private final float sampleRate;
     private final int durationSeconds;
     private final WaveformPeaks waveformPeaks;
-
-    @Deprecated(since = "3.3", forRemoval = false)
-    public AudioData(int[][] rawData, File sourceFile, float sampleRate) {
-        this.rawData = rawData;
-        this.sourceFile = sourceFile;
-        this.sampleRate = (sampleRate < 0) ? 44100f : sampleRate;
-        this.durationSeconds = (int) (rawData[0].length / sampleRate);
-        this.waveformPeaks = new WaveformPeaks(rawData.length, this.sampleRate, 512);
-    }
 
     /**
      * Lightweight constructor used by the new streaming pipeline.
      */
     public AudioData(File sourceFile) {
-        this.rawData = null;
         this.sourceFile = sourceFile;
         this.metadata = AudioMetadata.fromFile(sourceFile);
-        this.sampleRate = 44100f;
         this.durationSeconds = Math.max(0, this.metadata.getDurationSeconds());
-        this.waveformPeaks = new WaveformPeaks(2, this.sampleRate, 512);
-    }
-
-    @Deprecated(since = "3.3", forRemoval = false)
-    public int[][] getRawData() {
-        return rawData;
-    }
-
-    @Deprecated(since = "3.3", forRemoval = false)
-    public float getSampleRate() {
-        return sampleRate;
+        this.waveformPeaks = new WaveformPeaks(2, 44100f, 512);
     }
 
     public int getDurationSeconds() {
@@ -135,7 +107,7 @@ public class AudioData {
         if (waveformPeaks.getBucketCount() > 0) {
             return generateWaveformImage(waveformPeaks.snapshotByChannel(), waveformPeaks.getFramesPerBucket());
         }
-        return generateWaveformImage(rawData, 1);
+        return null;
     }
 
     /**

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
@@ -40,12 +40,26 @@ public class AudioData {
     private AudioMetadata metadata;
     private final float sampleRate;
     private final int durationSeconds;
+    private final WaveformPeaks waveformPeaks;
 
     public AudioData(int[][] rawData, File sourceFile, float sampleRate) {
         this.rawData = rawData;
         this.sourceFile = sourceFile;
         this.sampleRate = (sampleRate < 0) ? 44100f : sampleRate;
         this.durationSeconds = (int) (rawData[0].length / sampleRate);
+        this.waveformPeaks = new WaveformPeaks(rawData.length, this.sampleRate, 512);
+    }
+
+    /**
+     * Lightweight constructor used by the new streaming pipeline.
+     */
+    public AudioData(File sourceFile) {
+        this.rawData = null;
+        this.sourceFile = sourceFile;
+        this.metadata = AudioMetadata.fromFile(sourceFile);
+        this.sampleRate = 44100f;
+        this.durationSeconds = Math.max(0, this.metadata.getDurationSeconds());
+        this.waveformPeaks = new WaveformPeaks(2, this.sampleRate, 512);
     }
 
     public int[][] getRawData() {
@@ -57,7 +71,14 @@ public class AudioData {
     }
 
     public int getDurationSeconds() {
-        return durationSeconds;
+        if (durationSeconds > 0) {
+            return durationSeconds;
+        }
+        if (metadata != null && metadata.getDurationSeconds() > 0) {
+            return metadata.getDurationSeconds();
+        }
+        long est = waveformPeaks.getDurationMillisEstimate();
+        return (int) (est / 1000L);
     }
 
     public File getSourceFile() {
@@ -88,9 +109,13 @@ public class AudioData {
      */
     public BufferedImage getWaveformImage() {
         if (waveformImage == null) {
-            waveformImage = generateWaveformImage(rawData);
+            waveformImage = generateWaveformImageSnapshot();
         }
         return waveformImage;
+    }
+
+    public WaveformPeaks getWaveformPeaks() {
+        return waveformPeaks;
     }
 
     /**
@@ -100,8 +125,19 @@ public class AudioData {
      * @return A BufferedImage representing audio data for our clip.
      */
     public BufferedImage regenerateWaveformImage() {
-        waveformImage = null;
-        return getWaveformImage();
+        waveformImage = generateWaveformImageSnapshot();
+        return waveformImage;
+    }
+
+    /**
+     * Generates a fresh waveform image from whichever backing data is currently available.
+     * This is synchronized so callers can safely invoke it from a background thread.
+     */
+    public synchronized BufferedImage generateWaveformImageSnapshot() {
+        if (waveformPeaks.getBucketCount() > 0) {
+            return generateWaveformImage(waveformPeaks.snapshotByChannel(), waveformPeaks.getFramesPerBucket());
+        }
+        return generateWaveformImage(rawData, 1);
     }
 
     /**
@@ -109,7 +145,7 @@ public class AudioData {
      *
      * @return A BufferedImage representing our audio, or null if we have no audio.
      */
-    private BufferedImage generateWaveformImage(int[][] audioData) {
+    private BufferedImage generateWaveformImage(int[][] audioData, int frameMultiplier) {
         BufferedImage waveform = null;
         if (audioData == null) {
             return waveform;
@@ -122,7 +158,17 @@ public class AudioData {
         topChannelIndex = (topChannelIndex >= audioData.length) ? audioData.length - 1 : topChannelIndex;
         btmChannelIndex = (btmChannelIndex >= audioData.length) ? audioData.length - 1 : btmChannelIndex;
 
-        // Go through the data and find our highest y values:
+        // Determine the horizontal sampling scale we will use in both passes.
+        int xScale = Math.max(1, config.getCompression().getXValue() / Math.max(1, frameMultiplier));
+        int width = Math.max(1, audioData[0].length / xScale);
+        if (width > config.getWidthLimit().getLimit()) {
+            width = config.getWidthLimit().getLimit();
+            xScale = Math.max(1, audioData[0].length / config.getWidthLimit().getLimit());
+            logger.log(Level.INFO, "AudioUtil: scaling waveform image down to fit X limit of {2} (you can change this in settings).",
+                       new Object[]{config.getCompression().getXValue(), xScale, config.getWidthLimit().getLimit()});
+        }
+
+        // Go through the data and find our highest y values using the final xScale:
         int averagedSample1 = 0;
         int averagedSample2 = 0;
         int averagedSampleCount = 0;
@@ -135,7 +181,7 @@ public class AudioData {
             averagedSample1 += sample1;
             averagedSample2 += sample2;
             averagedSampleCount++;
-            if (averagedSampleCount > config.getCompression().getXValue()) {
+            if (averagedSampleCount >= xScale) {
                 averagedSample1 /= averagedSampleCount;
                 averagedSample2 /= averagedSampleCount;
 
@@ -147,15 +193,6 @@ public class AudioData {
             }
         }
 
-        // We can now create a blank image of the appropriate size based on this scale:
-        int xScale = config.getCompression().getXValue();
-        int width = audioData[0].length / config.getCompression().getXValue();
-        if (width > config.getWidthLimit().getLimit()) {
-            width = config.getWidthLimit().getLimit();
-            xScale = audioData[0].length / config.getWidthLimit().getLimit();
-            logger.log(Level.INFO, "AudioUtil: scaling waveform image down to fit X limit of {2} (you can change this in settings).",
-                       new Object[]{config.getCompression().getXValue(), xScale, config.getWidthLimit().getLimit()});
-        }
         int height = maxY1 + maxY2;
         height = (height <= 0) ? 100 : height; // height can be zero if there's no audio data.
         int verticalMargin = 0; // (int)((maxY1+maxY2)*0.1); // disabling margin for now
@@ -171,12 +208,12 @@ public class AudioData {
         int previousSample1 = 0;
         int previousSample2 = 0;
         int x = 0;
-        for (int sample = 0; sample < audioData[0].length; sample++) {
+        for (int sample = 0; sample < audioData[0].length && x < width; sample++) {
             averagedSample1 += Math.abs(audioData[topChannelIndex][sample] / config.getCompression().getYValue());
             averagedSample2 += Math.abs(audioData[btmChannelIndex][sample] / config.getCompression().getYValue());
             averagedSampleCount++;
 
-            if (averagedSampleCount > xScale) {
+            if (averagedSampleCount >= xScale) {
                 averagedSample1 /= averagedSampleCount;
                 averagedSample2 /= averagedSampleCount;
 
@@ -246,41 +283,4 @@ public class AudioData {
         return config;
     }
 
-    /**
-     * Id3 tags apparently encode the track duration in microseconds, which seems overkillish
-     * to me, but okay. This method will convert some ungodly huge number to a human-readable
-     * time string.
-     *
-     * @param value A value in microseconds.
-     * @return A human readable string in the form [[HH:]MM:]SS
-     */
-    private String formatMicroseconds(Long value) {
-        if (value == null) {
-            return " (n/a) ";
-        }
-
-        int seconds = (int) (value / 1000 / 1000);
-        int hours = 0;
-        int minutes = 0;
-        while (seconds > 3600) {
-            seconds -= 3600;
-            hours++;
-        }
-        while (seconds > 60) {
-            seconds -= 60;
-            minutes++;
-        }
-
-        StringBuilder sb = new StringBuilder();
-        if (hours > 0) {
-            sb.append(hours);
-            sb.append(":");
-        }
-        if (hours > 0 || minutes > 0) {
-            sb.append(String.format("%02d", minutes));
-            sb.append(":");
-        }
-        sb.append(String.format("%02d", seconds));
-        return sb.toString();
-    }
 }

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioData.java
@@ -4,14 +4,14 @@ import ca.corbett.extras.audio.WaveformConfig;
 import ca.corbett.musicplayer.AppConfig;
 import ca.corbett.musicplayer.ui.AppTheme;
 
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
 
 /**
  * A wrapper class to encapsulate a single audio clip.
@@ -53,7 +53,7 @@ public class AudioData {
             float sampleRate = format.getSampleRate() > 0 ? format.getSampleRate() : DEFAULT_WAVEFORM_SAMPLE_RATE;
             return new WaveformPeaks(channels, sampleRate, DEFAULT_WAVEFORM_FRAMES_PER_BUCKET);
         } catch (Exception ex) {
-            logger.log(Level.FINE,
+            logger.log(Level.WARNING,
                     "Unable to determine audio format for waveform peak initialization, using defaults for "
                             + sourceFile,
                     ex);

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioUtil.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioUtil.java
@@ -60,6 +60,8 @@ public class AudioUtil {
     }
 
     /**
+     * @deprecated Legacy raw-buffer loading path kept for compatibility.
+     *             The active pipeline now uses lightweight metadata load plus background peak generation.
      * Invoked from AudioLoadThread when we have some audio data to be processed.
      * The current audio load implementation is a bit wonky and I'm not happy with it,
      * but it goes like this:
@@ -80,6 +82,7 @@ public class AudioUtil {
      * @throws UnsupportedAudioFileException Officially we support wav and mp3 but there's probably others not tested.
      * @throws IOException                   In case of i/o error.
      */
+    @Deprecated(since = "3.3", forRemoval = false)
     public static AudioData load(File sourceFile, File convertedFile) throws UnsupportedAudioFileException, IOException {
         AudioInputStream inputStream = AudioSystem.getAudioInputStream(convertedFile == null ? sourceFile : convertedFile);
 
@@ -174,12 +177,14 @@ public class AudioUtil {
     }
 
     /**
+     * @deprecated Legacy helper retained for compatibility; playback now streams directly from source files.
      * Constructs an AudioInputStream based on the parsed audio data. This is mainly used
      * to play a clip that has been parsed by one of the parseAudio methods in this class.
      *
      * @param audioData An AudioData instance.
      * @return An AudioInputStream ready to be read.
      */
+    @Deprecated(since = "3.3", forRemoval = false)
     public static AudioInputStream getAudioInputStream(AudioData audioData) {
         // Legacy helper retained for waveform-related code paths.
         // Audio saving code cobbled together from
@@ -204,6 +209,7 @@ public class AudioUtil {
     }
 
     /**
+     * @deprecated Legacy conversion helper retained for compatibility.
      * Invoked as needed from AudioLoadThread. If the file we're trying to load was in mp3
      * format, this will be invoked to convert it to wav format so we can process
      * the raw audio data.
@@ -212,9 +218,16 @@ public class AudioUtil {
      * @return A file in the system temp dir that contains the converted data in wav format
      * @throws IOException If something goes wrong.
      */
+    @Deprecated(since = "3.3", forRemoval = false)
     public static File convert(AudioInputStream inStream) throws IOException {
         AudioFormat sourceFormat = inStream.getFormat();
-        AudioFormat targetFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, sourceFormat.getSampleRate(), 16, sourceFormat.getChannels(), 4, sourceFormat.getFrameRate(), false);
+        AudioFormat targetFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED,
+                                                   sourceFormat.getSampleRate(),
+                                                   16,
+                                                   sourceFormat.getChannels(),
+                                                   sourceFormat.getChannels() * 2,
+                                                   sourceFormat.getSampleRate(),
+                                                   false);
         if (!AudioSystem.isConversionSupported(targetFormat, inStream.getFormat())) {
             logger.severe("Audio conversion not possible for this track :(");
             return null;

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioUtil.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioUtil.java
@@ -123,10 +123,54 @@ public class AudioUtil {
     }
 
     public static PlaybackThread play(AudioData data, long offset, PlaybackListener listener) throws IOException, LineUnavailableException {
-        AudioInputStream audioStream = getAudioInputStream(data);
+        if (data == null || data.getSourceFile() == null) {
+            throw new IOException("No audio source file is available for playback.");
+        }
+
+        AudioInputStream audioStream = openPlaybackStream(data.getSourceFile());
         PlaybackThread thread = new PlaybackThread(audioStream, offset, 0, listener);
         new Thread(thread).start();
         return thread;
+    }
+
+    /**
+     * Opens an audio stream suitable for immediate playback from the given source file.
+     * For mp3 files, we decode to 16-bit PCM on the fly using the installed Java Sound SPI.
+     * For already-playable PCM files, this simply returns the source stream.
+     */
+    public static AudioInputStream openPlaybackStream(File sourceFile) throws IOException {
+        AudioInputStream sourceStream;
+        try {
+            sourceStream = AudioSystem.getAudioInputStream(sourceFile);
+        }
+        catch (UnsupportedAudioFileException e) {
+            throw new IOException("Unsupported source audio file: " + sourceFile.getName(), e);
+        }
+        AudioFormat sourceFormat = sourceStream.getFormat();
+
+        // Keep playback format consistent for mp3/wav by targeting signed 16-bit little-endian PCM.
+        AudioFormat targetFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED,
+                                                   sourceFormat.getSampleRate(),
+                                                   16,
+                                                   sourceFormat.getChannels(),
+                                                   sourceFormat.getChannels() * 2,
+                                                   sourceFormat.getSampleRate(),
+                                                   false);
+
+        if (AudioSystem.isConversionSupported(targetFormat, sourceFormat)) {
+            return AudioSystem.getAudioInputStream(targetFormat, sourceStream);
+        }
+
+        // If conversion is unsupported but the stream is already in a sensible playback format,
+        // return it as-is instead of failing fast.
+        if (sourceFormat.getEncoding() == AudioFormat.Encoding.PCM_SIGNED
+            && sourceFormat.getSampleSizeInBits() == 16
+            && sourceFormat.getChannels() > 0) {
+            return sourceStream;
+        }
+
+        sourceStream.close();
+        throw new IOException("Unsupported playback format: " + sourceFormat);
     }
 
     /**
@@ -137,6 +181,7 @@ public class AudioUtil {
      * @return An AudioInputStream ready to be read.
      */
     public static AudioInputStream getAudioInputStream(AudioData audioData) {
+        // Legacy helper retained for waveform-related code paths.
         // Audio saving code cobbled together from
         //  https://stackoverflow.com/questions/3297749/java-reading-manipulating-and-writing-wav-files
 

--- a/src/main/java/ca/corbett/musicplayer/audio/AudioUtil.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/AudioUtil.java
@@ -3,28 +3,24 @@ package ca.corbett.musicplayer.audio;
 import ca.corbett.extras.audio.PlaybackListener;
 import ca.corbett.extras.audio.PlaybackThread;
 
-import javax.sound.sampled.AudioFileFormat;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.UnsupportedAudioFileException;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 /**
- * Provides utility methods for loading and handling AudioData.
- * This was based heavily on AudioUtil in swing-extras but modified
- * for this application.
+ * Utility helpers for audio-file validation and streaming playback.
+ *
+ * The active pipeline is source-file based: metadata is loaded separately and
+ * playback streams decoded PCM directly from the source file.
  *
  * @author scorbo2
- * @since 2025-03-23 (copy+paste+modified from AudioUtil)
+ * @since 2025-03-23
  */
 public class AudioUtil {
-
-    private static final Logger logger = Logger.getLogger(AudioUtil.class.getName());
 
     private AudioUtil() {
     }
@@ -59,72 +55,20 @@ public class AudioUtil {
             filename.endsWith(".mplist");
     }
 
-    /**
-     * @deprecated Legacy raw-buffer loading path kept for compatibility.
-     *             The active pipeline now uses lightweight metadata load plus background peak generation.
-     * Invoked from AudioLoadThread when we have some audio data to be processed.
-     * The current audio load implementation is a bit wonky and I'm not happy with it,
-     * but it goes like this:
-     * <ol>
-     *     <li>If the file is a wav file, just load the audio data and we're done.</li>
-     *     <li>If it's an mp3, convert it to wav and write the wav to the system temp dir.</li>
-     *     <li>Then, load the audio data from that temp file and delete the temp file.</li>
-     * </ol>
-     * The end result is an AudioData object containing the raw audio data. This is horribly
-     * inefficient memory-wise but it allows waveform generation and the ability to click
-     * in the waveform panel to start playing from whatever location, which I can't seem to
-     * figure out how to do with mp3spi and/or jlayer. But I'm sure it's possible,
-     * so TODO revisit this and smarten this up.
-     *
-     * @param sourceFile The File containing the audio data. Must be in a supported format.
-     * @param convertedFile If audio conversion was required (see above), this is the temporary converted file.
-     * @return An instance of AudioData which will be partially populated (lazy loading on some stuff).
-     * @throws UnsupportedAudioFileException Officially we support wav and mp3 but there's probably others not tested.
-     * @throws IOException                   In case of i/o error.
-     */
-    @Deprecated(since = "3.3", forRemoval = false)
-    public static AudioData load(File sourceFile, File convertedFile) throws UnsupportedAudioFileException, IOException {
-        AudioInputStream inputStream = AudioSystem.getAudioInputStream(convertedFile == null ? sourceFile : convertedFile);
-
-        int frameLength = (int) inputStream.getFrameLength();
-        int frameSize = inputStream.getFormat().getFrameSize();
-
-        // Odd NegativeArraySize exception can be thrown below, see AREC-10:
-        if (frameLength < 0 || frameSize < 0 || (frameLength * frameSize) < 0) {
-            throw new IOException("Empty or corrupt Audio stream.");
-        }
-
-        byte[] byteArray = new byte[frameLength * frameSize];
-        inputStream.read(byteArray);
-
-        if (convertedFile != null) {
-            convertedFile.delete();
-        }
-
-        // Now we'll split our byte array into channels and samples.
-        int numChannels = inputStream.getFormat().getChannels();
-        int[][] audioData = new int[numChannels][frameLength];
-        int sampleIndex = 0;
-        for (int t = 0; t < byteArray.length; ) {
-            for (int channel = 0; channel < numChannels; channel++) {
-                int lowByte = byteArray[t++];
-                int highByte = byteArray[t++];
-                int sample = (highByte << 8) | (lowByte & 0x00ff);
-                audioData[channel][sampleIndex] = sample;
-            }
-            sampleIndex++;
-        }
-
-        float sampleRate = inputStream.getFormat().getSampleRate();
-        inputStream.close();
-
-        return new AudioData(audioData, sourceFile, sampleRate);
-    }
-
     public static PlaybackThread play(AudioData data, PlaybackListener listener) throws IOException, LineUnavailableException {
         return play(data, 0, listener);
     }
 
+    /**
+     * Starts playback from the given track at the requested millisecond offset.
+     *
+     * Playback is streamed from the source file and decoded to PCM on demand.
+     *
+     * @param data     Track wrapper with a valid source file.
+     * @param offset   Start offset in milliseconds.
+     * @param listener Playback callback listener.
+     * @return The running playback thread.
+     */
     public static PlaybackThread play(AudioData data, long offset, PlaybackListener listener) throws IOException, LineUnavailableException {
         if (data == null || data.getSourceFile() == null) {
             throw new IOException("No audio source file is available for playback.");
@@ -139,7 +83,10 @@ public class AudioUtil {
     /**
      * Opens an audio stream suitable for immediate playback from the given source file.
      * For mp3 files, we decode to 16-bit PCM on the fly using the installed Java Sound SPI.
-     * For already-playable PCM files, this simply returns the source stream.
+     * For already-playable 16-bit signed PCM files, this returns the source stream.
+     *
+     * @param sourceFile Audio file to open.
+     * @return A stream in a playback-compatible PCM format.
      */
     public static AudioInputStream openPlaybackStream(File sourceFile) throws IOException {
         AudioInputStream sourceStream;
@@ -174,74 +121,5 @@ public class AudioUtil {
 
         sourceStream.close();
         throw new IOException("Unsupported playback format: " + sourceFormat);
-    }
-
-    /**
-     * @deprecated Legacy helper retained for compatibility; playback now streams directly from source files.
-     * Constructs an AudioInputStream based on the parsed audio data. This is mainly used
-     * to play a clip that has been parsed by one of the parseAudio methods in this class.
-     *
-     * @param audioData An AudioData instance.
-     * @return An AudioInputStream ready to be read.
-     */
-    @Deprecated(since = "3.3", forRemoval = false)
-    public static AudioInputStream getAudioInputStream(AudioData audioData) {
-        // Legacy helper retained for waveform-related code paths.
-        // Audio saving code cobbled together from
-        //  https://stackoverflow.com/questions/3297749/java-reading-manipulating-and-writing-wav-files
-
-        // Convert the int array into a single byte array:
-        int[][] sourceData = audioData.getRawData();
-        byte[] byteArray = new byte[sourceData[0].length * sourceData.length * 2];
-        int sample = 0;
-        for (int i = 0; i < byteArray.length; ) {
-            for (int channel = 0; channel < sourceData.length; channel++) {
-                byteArray[i++] = (byte) (sourceData[channel][sample] & 0xff);
-                byteArray[i++] = (byte) (sourceData[channel][sample] >>> 8);
-            }
-            sample++;
-        }
-
-        AudioFormat format = new AudioFormat(audioData.getSampleRate(), 16, sourceData.length, true, false);
-        ByteArrayInputStream bais = new ByteArrayInputStream(byteArray);
-        AudioInputStream audioStream = new AudioInputStream(bais, format, sourceData[0].length);
-        return audioStream;
-    }
-
-    /**
-     * @deprecated Legacy conversion helper retained for compatibility.
-     * Invoked as needed from AudioLoadThread. If the file we're trying to load was in mp3
-     * format, this will be invoked to convert it to wav format so we can process
-     * the raw audio data.
-     *
-     * @param inStream An audio input stream from the source file
-     * @return A file in the system temp dir that contains the converted data in wav format
-     * @throws IOException If something goes wrong.
-     */
-    @Deprecated(since = "3.3", forRemoval = false)
-    public static File convert(AudioInputStream inStream) throws IOException {
-        AudioFormat sourceFormat = inStream.getFormat();
-        AudioFormat targetFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED,
-                                                   sourceFormat.getSampleRate(),
-                                                   16,
-                                                   sourceFormat.getChannels(),
-                                                   sourceFormat.getChannels() * 2,
-                                                   sourceFormat.getSampleRate(),
-                                                   false);
-        if (!AudioSystem.isConversionSupported(targetFormat, inStream.getFormat())) {
-            logger.severe("Audio conversion not possible for this track :(");
-            return null;
-        }
-        AudioInputStream convertedStream = AudioSystem.getAudioInputStream(targetFormat, inStream);
-        File tmpFile = File.createTempFile("mp_", ".wav");
-        try {
-            AudioSystem.write(convertedStream, AudioFileFormat.Type.WAVE, tmpFile);
-        }
-        catch (ArrayIndexOutOfBoundsException oobe) {
-            // Some older mp3 files throw this - it doesn't happen very often, but it does
-            // happen on some corrupt files.
-            throw new IOException("Failed to load audio stream - file is corrupt.", oobe);
-        }
-        return tmpFile;
     }
 }

--- a/src/main/java/ca/corbett/musicplayer/audio/WaveformPeaks.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/WaveformPeaks.java
@@ -1,0 +1,85 @@
+package ca.corbett.musicplayer.audio;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Compact waveform data represented as peak amplitudes per bucket.
+ */
+public class WaveformPeaks {
+
+    private final int channels;
+    private final float sampleRate;
+    private final int framesPerBucket;
+    private final List<short[]> buckets;
+    private volatile boolean complete;
+
+    public WaveformPeaks(int channels, float sampleRate, int framesPerBucket) {
+        this.channels = Math.max(1, channels);
+        this.sampleRate = sampleRate > 0 ? sampleRate : 44100f;
+        this.framesPerBucket = Math.max(1, framesPerBucket);
+        this.buckets = new ArrayList<>();
+        this.complete = false;
+    }
+
+    public synchronized void addBucket(short[] bucket) {
+        if (bucket == null || bucket.length == 0) {
+            return;
+        }
+        short[] copy = new short[channels];
+
+        // For mono inputs, mirror the single channel so top/bottom waveform stays symmetric.
+        if (bucket.length == 1) {
+            for (int i = 0; i < copy.length; i++) {
+                copy[i] = bucket[0];
+            }
+            buckets.add(copy);
+            return;
+        }
+
+        for (int i = 0; i < copy.length; i++) {
+            copy[i] = i < bucket.length ? bucket[i] : 0;
+        }
+        buckets.add(copy);
+    }
+
+    public synchronized int[][] snapshotByChannel() {
+        int[][] out = new int[channels][buckets.size()];
+        for (int i = 0; i < buckets.size(); i++) {
+            short[] bucket = buckets.get(i);
+            for (int ch = 0; ch < channels; ch++) {
+                out[ch][i] = bucket[ch];
+            }
+        }
+        return out;
+    }
+
+    public synchronized int getBucketCount() {
+        return buckets.size();
+    }
+
+    public int getChannels() {
+        return channels;
+    }
+
+    public float getSampleRate() {
+        return sampleRate;
+    }
+
+    public int getFramesPerBucket() {
+        return framesPerBucket;
+    }
+
+    public long getDurationMillisEstimate() {
+        return (long) ((getBucketCount() * (double) framesPerBucket / sampleRate) * 1000d);
+    }
+
+    public boolean isComplete() {
+        return complete;
+    }
+
+    public void setComplete(boolean complete) {
+        this.complete = complete;
+    }
+}
+

--- a/src/main/java/ca/corbett/musicplayer/audio/WaveformPeaks.java
+++ b/src/main/java/ca/corbett/musicplayer/audio/WaveformPeaks.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 /**
  * Compact waveform data represented as peak amplitudes per bucket.
+ *
+ * Instances are appended to by a background decode thread while the UI thread reads
+ * snapshots for rendering, so mutable operations are synchronized.
  */
 public class WaveformPeaks {
 
@@ -22,6 +25,12 @@ public class WaveformPeaks {
         this.complete = false;
     }
 
+    /**
+     * Adds a single peak bucket.
+     *
+     * If the source bucket is mono (length 1), the value is mirrored into all channels
+     * to preserve symmetric top/bottom waveform rendering.
+     */
     public synchronized void addBucket(short[] bucket) {
         if (bucket == null || bucket.length == 0) {
             return;
@@ -43,6 +52,9 @@ public class WaveformPeaks {
         buckets.add(copy);
     }
 
+    /**
+     * Returns an immutable-style snapshot arranged as [channel][bucketIndex].
+     */
     public synchronized int[][] snapshotByChannel() {
         int[][] out = new int[channels][buckets.size()];
         for (int i = 0; i < buckets.size(); i++) {
@@ -54,6 +66,9 @@ public class WaveformPeaks {
         return out;
     }
 
+    /**
+     * Returns the number of peak buckets currently collected.
+     */
     public synchronized int getBucketCount() {
         return buckets.size();
     }
@@ -70,6 +85,11 @@ public class WaveformPeaks {
         return framesPerBucket;
     }
 
+    /**
+     * Returns an estimated duration based on collected bucket count.
+     *
+     * This is most useful while background peak generation is still in progress.
+     */
     public long getDurationMillisEstimate() {
         return (long) ((getBucketCount() * (double) framesPerBucket / sampleRate) * 1000d);
     }

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
@@ -1,0 +1,173 @@
+package ca.corbett.musicplayer.ui;
+
+import ca.corbett.extras.MessageUtil;
+import ca.corbett.musicplayer.audio.AudioData;
+
+import javax.swing.SwingUtilities;
+import java.io.File;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Coordinates track load requests so that only the most recent request is allowed
+ * to affect the UI. Requests are serialized onto a single background worker and
+ * rapid repeated requests are coalesced down to the latest pending file.
+ *
+ * @author scorbo2
+ * @since 2026-04-11
+ */
+public final class AudioLoadCoordinator {
+
+    private static final Logger logger = Logger.getLogger(AudioLoadCoordinator.class.getName());
+    private static AudioLoadCoordinator instance;
+
+    private final AtomicLong requestCounter = new AtomicLong(0);
+    private final AtomicLong latestRequestId = new AtomicLong(0);
+    private final Object requestLock = new Object();
+    private final Thread workerThread;
+    private volatile LoadRequest pendingRequest;
+    private volatile boolean running = true;
+    private MessageUtil messageUtil;
+
+    private AudioLoadCoordinator() {
+        workerThread = new Thread(this::processRequests, "musicplayer-audio-loader");
+        workerThread.setDaemon(true);
+        workerThread.start();
+    }
+
+    public static synchronized AudioLoadCoordinator getInstance() {
+        if (instance == null) {
+            instance = new AudioLoadCoordinator();
+        }
+        return instance;
+    }
+
+    /**
+     * Queues a request to load the given file. If another request is already pending,
+     * it is replaced by this one.
+     *
+     * @param sourceFile The audio file to load.
+     * @return The request id assigned to this request.
+     */
+    public long requestLoad(File sourceFile) {
+        if (sourceFile == null) {
+            return latestRequestId.get();
+        }
+
+        long requestId = requestCounter.incrementAndGet();
+        latestRequestId.set(requestId);
+        synchronized (requestLock) {
+            pendingRequest = new LoadRequest(requestId, sourceFile);
+            requestLock.notifyAll();
+        }
+        return requestId;
+    }
+
+    /**
+     * Invalidates any current or pending load request so late results are ignored.
+     * This is useful when the user hits stop while a background load is still running.
+     */
+    public void cancelPendingRequests() {
+        latestRequestId.incrementAndGet();
+        synchronized (requestLock) {
+            pendingRequest = null;
+            requestLock.notifyAll();
+        }
+        workerThread.interrupt();
+    }
+
+    public long getLatestRequestId() {
+        return latestRequestId.get();
+    }
+
+    public boolean isCurrentRequest(long requestId) {
+        return requestId > 0 && latestRequestId.get() == requestId;
+    }
+
+    public void shutdown() {
+        running = false;
+        synchronized (requestLock) {
+            pendingRequest = null;
+            requestLock.notifyAll();
+        }
+        workerThread.interrupt();
+    }
+
+    private void processRequests() {
+        while (running) {
+            LoadRequest request = waitForNextRequest();
+            if (!running || request == null) {
+                continue;
+            }
+
+            if (!isCurrentRequest(request.requestId)) {
+                continue;
+            }
+
+            AudioLoadThread loader = new AudioLoadThread(request.sourceFile, () -> running && isCurrentRequest(request.requestId));
+            try {
+                AudioData audioData = loader.loadAudioData();
+                if (audioData == null || !isCurrentRequest(request.requestId)) {
+                    continue;
+                }
+
+                SwingUtilities.invokeLater(() -> {
+                    if (!isCurrentRequest(request.requestId)) {
+                        return;
+                    }
+
+                    AudioPanel panel = AudioPanel.getInstance();
+                    if (panel.applyLoadedAudioData(request.requestId, audioData)) {
+                        panel.playRequest(request.requestId);
+                    }
+                });
+            }
+            catch (InterruptedException ignored) {
+                Thread.interrupted();
+            }
+            catch (Exception exc) {
+                if (!isCurrentRequest(request.requestId)) {
+                    logger.log(Level.FINE, "Ignoring stale audio load failure for {0}: {1}",
+                               new Object[]{request.sourceFile.getName(), exc.getMessage()});
+                    continue;
+                }
+                getMessageUtil().error("Problem loading file: " + exc.getMessage(), exc);
+            }
+        }
+    }
+
+    private LoadRequest waitForNextRequest() {
+        synchronized (requestLock) {
+            while (running && pendingRequest == null) {
+                try {
+                    requestLock.wait();
+                }
+                catch (InterruptedException ignored) {
+                    Thread.interrupted();
+                }
+            }
+            if (!running) {
+                return null;
+            }
+
+            LoadRequest request = pendingRequest;
+            pendingRequest = null;
+            return request;
+        }
+    }
+
+    private MessageUtil getMessageUtil() {
+        if (messageUtil == null) {
+            messageUtil = new MessageUtil(MainWindow.getInstance(), logger);
+        }
+        return messageUtil;
+    }
+
+    private record LoadRequest(long requestId, File sourceFile) {
+        private LoadRequest {
+            Objects.requireNonNull(sourceFile);
+        }
+    }
+}

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
@@ -200,13 +200,34 @@ public final class AudioLoadCoordinator {
         }
     }
 
+    /**
+     * Returns true if a waveform UI refresh should be skipped due to throttling.
+     * Package-private to allow unit testing of the throttle logic.
+     */
+    boolean isWaveformRefreshThrottled(boolean forceRefresh) {
+        if (forceRefresh) {
+            return false;
+        }
+        long now = System.currentTimeMillis();
+        return waveformRefreshQueued || (now - lastWaveformUiRefreshMillis) < MIN_WAVEFORM_REFRESH_INTERVAL_MS;
+    }
+
+    /** For testing only: sets the last waveform UI refresh timestamp. */
+    void setLastWaveformRefreshMillisForTesting(long millis) {
+        lastWaveformUiRefreshMillis = millis;
+    }
+
+    /** For testing only: sets the waveform refresh queued flag. */
+    void setWaveformRefreshQueuedForTesting(boolean queued) {
+        waveformRefreshQueued = queued;
+    }
+
     private void requestWaveformRefresh(long requestId, boolean forceRefresh) {
         if (!running || !isCurrentRequest(requestId) || waveformRequestId != requestId) {
             return;
         }
 
-        long now = System.currentTimeMillis();
-        if (!forceRefresh && (waveformRefreshQueued || (now - lastWaveformUiRefreshMillis) < MIN_WAVEFORM_REFRESH_INTERVAL_MS)) {
+        if (isWaveformRefreshThrottled(forceRefresh)) {
             return;
         }
 

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
@@ -20,6 +20,8 @@ import java.util.logging.Logger;
  */
 public final class AudioLoadCoordinator {
 
+    private static final long MIN_WAVEFORM_REFRESH_INTERVAL_MS = 500;
+
     private static final Logger logger = Logger.getLogger(AudioLoadCoordinator.class.getName());
     private static AudioLoadCoordinator instance;
 
@@ -28,6 +30,10 @@ public final class AudioLoadCoordinator {
     private final Object requestLock = new Object();
     private final Thread workerThread;
     private volatile LoadRequest pendingRequest;
+    private volatile WaveformBuildThread waveformBuildThread;
+    private volatile long waveformRequestId;
+    private volatile long lastWaveformUiRefreshMillis;
+    private volatile boolean waveformRefreshQueued;
     private volatile boolean running = true;
     private MessageUtil messageUtil;
 
@@ -75,6 +81,7 @@ public final class AudioLoadCoordinator {
             pendingRequest = null;
             requestLock.notifyAll();
         }
+        stopWaveformBuild();
         workerThread.interrupt();
     }
 
@@ -92,6 +99,7 @@ public final class AudioLoadCoordinator {
             pendingRequest = null;
             requestLock.notifyAll();
         }
+        stopWaveformBuild();
         workerThread.interrupt();
     }
 
@@ -121,6 +129,7 @@ public final class AudioLoadCoordinator {
                     AudioPanel panel = AudioPanel.getInstance();
                     if (panel.applyLoadedAudioData(request.requestId, audioData)) {
                         panel.playRequest(request.requestId);
+                        startWaveformBuild(request.requestId, audioData);
                     }
                 });
             }
@@ -163,6 +172,54 @@ public final class AudioLoadCoordinator {
             messageUtil = new MessageUtil(MainWindow.getInstance(), logger);
         }
         return messageUtil;
+    }
+
+    private void startWaveformBuild(long requestId, AudioData audioData) {
+        stopWaveformBuild();
+        if (audioData == null || audioData.getSourceFile() == null) {
+            return;
+        }
+
+        waveformRequestId = requestId;
+        lastWaveformUiRefreshMillis = 0L;
+        waveformRefreshQueued = false;
+        waveformBuildThread = new WaveformBuildThread(audioData.getSourceFile(),
+                                                      audioData.getWaveformPeaks(),
+                                                      () -> running && isCurrentRequest(requestId) && waveformRequestId == requestId,
+                                                      () -> requestWaveformRefresh(requestId, audioData.getWaveformPeaks().isComplete()));
+        waveformBuildThread.start();
+    }
+
+    private void stopWaveformBuild() {
+        waveformRequestId = 0L;
+        waveformRefreshQueued = false;
+        lastWaveformUiRefreshMillis = 0L;
+        if (waveformBuildThread != null) {
+            waveformBuildThread.interrupt();
+            waveformBuildThread = null;
+        }
+    }
+
+    private void requestWaveformRefresh(long requestId, boolean forceRefresh) {
+        if (!running || !isCurrentRequest(requestId) || waveformRequestId != requestId) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        if (!forceRefresh && (waveformRefreshQueued || (now - lastWaveformUiRefreshMillis) < MIN_WAVEFORM_REFRESH_INTERVAL_MS)) {
+            return;
+        }
+
+        waveformRefreshQueued = true;
+        SwingUtilities.invokeLater(() -> {
+            waveformRefreshQueued = false;
+            if (!running || !isCurrentRequest(requestId) || waveformRequestId != requestId) {
+                return;
+            }
+
+            lastWaveformUiRefreshMillis = System.currentTimeMillis();
+            AudioPanel.getInstance().refreshWaveformForRequest(requestId);
+        });
     }
 
     private record LoadRequest(long requestId, File sourceFile) {

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadCoordinator.java
@@ -76,7 +76,7 @@ public final class AudioLoadCoordinator {
      * This is useful when the user hits stop while a background load is still running.
      */
     public void cancelPendingRequests() {
-        latestRequestId.incrementAndGet();
+        latestRequestId.set(requestCounter.incrementAndGet());
         synchronized (requestLock) {
             pendingRequest = null;
             requestLock.notifyAll();

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadThread.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadThread.java
@@ -9,12 +9,11 @@ import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
 
 /**
- * A simple worker thread to load audio data from a given file.
- * Upon completion, the audio data will be loaded into the audio
- * panel and played automatically. If something goes wrong, an
- * error will be logged and displayed to the user.
- * A progress monitor is supplied so the user has some idea
- * that work is being done.
+ * A simple worker that performs lightweight track loading for a given file.
+ *
+ * The current implementation only parses metadata and creates an {@link AudioData}
+ * wrapper. Waveform peak extraction is performed later on a separate background
+ * thread managed by {@link AudioLoadCoordinator}.
  *
  * @author scorbo2
  * @since 2025-04-02

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadThread.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadThread.java
@@ -9,6 +9,7 @@ import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import java.io.File;
 import java.io.IOException;
+import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
 
 /**
@@ -26,42 +27,72 @@ public class AudioLoadThread extends MultiProgressWorker {
 
     private static final Logger logger = Logger.getLogger(AudioLoadThread.class.getName());
     private final File sourceFile;
+    private final BooleanSupplier keepGoing;
     private MessageUtil messageUtil;
 
     public AudioLoadThread(File inputFile) {
+        this(inputFile, () -> true);
+    }
+
+    public AudioLoadThread(File inputFile, BooleanSupplier keepGoing) {
         sourceFile = inputFile;
+        this.keepGoing = keepGoing == null ? () -> true : keepGoing;
     }
 
     @Override
     public void run() {
         try {
-            fireProgressBegins(2);
-            fireMajorProgressUpdate(1, 3, "Loading " + sourceFile.getName() + "...");
-            fireMinorProgressUpdate(1, 0, "Converting audio...");
+            AudioData audioData = loadAudioData();
+            if (audioData != null) {
+                fireProgressComplete();
+            }
+        }
+        catch (InterruptedException ignored) {
+            Thread.interrupted();
+        } catch (Exception e) {
+            getMessageUtil().error("Problem loading file: " + e.getMessage(), e);
+        }
+    }
 
+    public AudioData loadAudioData() throws Exception {
+        fireProgressBegins(2);
+        fireMajorProgressUpdate(1, 3, "Loading " + sourceFile.getName() + "...");
+        fireMinorProgressUpdate(1, 0, "Converting audio...");
+
+        checkCanceled();
+
+        File convertedFile = null;
+        try {
             // Convert if necessary from mp3 to wav:
-            File convertedFile = null;
             if (sourceFile.getName().toLowerCase().endsWith(".mp3")) {
-                AudioInputStream sourceStream = AudioSystem.getAudioInputStream(sourceFile);
-                convertedFile = AudioUtil.convert(sourceStream);
+                try (AudioInputStream sourceStream = AudioSystem.getAudioInputStream(sourceFile)) {
+                    convertedFile = AudioUtil.convert(sourceStream);
+                }
                 if (convertedFile == null) {
                     throw new IOException("Decode mp3 failed!");
                 }
             }
 
             fireMinorProgressUpdate(1, 1, "Parsing converted data...");
+            checkCanceled();
 
-            // Now load this audio stream:
             AudioData audioData = AudioUtil.load(sourceFile, convertedFile);
+            convertedFile = null; // AudioUtil.load deletes it after successful parse.
 
             fireMinorProgressUpdate(1, 2, "Processing audio...");
+            checkCanceled();
+            return audioData;
+        }
+        finally {
+            if (convertedFile != null && convertedFile.exists()) {
+                convertedFile.delete();
+            }
+        }
+    }
 
-            // If we get this far, set the audio data and play it:
-            AudioPanel.getInstance().setAudioData(audioData);
-            fireProgressComplete();
-            AudioPanel.getInstance().play();
-        } catch (Exception e) {
-            getMessageUtil().error("Problem loading file: " + e.getMessage(), e);
+    private void checkCanceled() throws InterruptedException {
+        if (Thread.currentThread().isInterrupted() || !keepGoing.getAsBoolean()) {
+            throw new InterruptedException("Audio load request was cancelled.");
         }
     }
 

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioLoadThread.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioLoadThread.java
@@ -3,12 +3,8 @@ package ca.corbett.musicplayer.ui;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.progress.MultiProgressWorker;
 import ca.corbett.musicplayer.audio.AudioData;
-import ca.corbett.musicplayer.audio.AudioUtil;
 
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
 import java.io.File;
-import java.io.IOException;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
 
@@ -55,39 +51,15 @@ public class AudioLoadThread extends MultiProgressWorker {
     }
 
     public AudioData loadAudioData() throws Exception {
-        fireProgressBegins(2);
-        fireMajorProgressUpdate(1, 3, "Loading " + sourceFile.getName() + "...");
-        fireMinorProgressUpdate(1, 0, "Converting audio...");
+        fireProgressBegins(1);
+        fireMajorProgressUpdate(1, 1, "Loading " + sourceFile.getName() + "...");
+        fireMinorProgressUpdate(1, 0, "Reading track metadata...");
 
         checkCanceled();
-
-        File convertedFile = null;
-        try {
-            // Convert if necessary from mp3 to wav:
-            if (sourceFile.getName().toLowerCase().endsWith(".mp3")) {
-                try (AudioInputStream sourceStream = AudioSystem.getAudioInputStream(sourceFile)) {
-                    convertedFile = AudioUtil.convert(sourceStream);
-                }
-                if (convertedFile == null) {
-                    throw new IOException("Decode mp3 failed!");
-                }
-            }
-
-            fireMinorProgressUpdate(1, 1, "Parsing converted data...");
-            checkCanceled();
-
-            AudioData audioData = AudioUtil.load(sourceFile, convertedFile);
-            convertedFile = null; // AudioUtil.load deletes it after successful parse.
-
-            fireMinorProgressUpdate(1, 2, "Processing audio...");
-            checkCanceled();
-            return audioData;
-        }
-        finally {
-            if (convertedFile != null && convertedFile.exists()) {
-                convertedFile.delete();
-            }
-        }
+        AudioData audioData = new AudioData(sourceFile);
+        fireMinorProgressUpdate(1, 1, "Preparing waveform generation...");
+        checkCanceled();
+        return audioData;
     }
 
     private void checkCanceled() throws InterruptedException {

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
@@ -34,11 +34,6 @@ import java.util.logging.Logger;
  * track, along with controls like next, prev, play, pause, and so on. Our list of control
  * buttons also reaches out to the extension manager so that extensions can register additional
  * action buttons for us to display on our control panel.
- * <p>
- * TODO saw an intermittent issue where if you set a manual mark position towards the
- *      very end of the clip and hit play, it won't play right to the end.
- *      Not sure, but seems like the playback thread might be miscalculating offset position.
- *      </p>
  *
  * @author scorbo2
  * @since 2025-03-23

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
@@ -59,8 +59,10 @@ public class AudioPanel extends JPanel implements UIReloadable {
     private AudioData audioData;
     private PlaybackThread playbackThread;
     private float playbackPosition; // 0f==start, 1f==end
-    private final PlaybackListener playbackListener;
     private final VisualizationTrackInfo trackInfo;
+    private long currentRequestId;
+    private long activePlaybackRequestId;
+    private long playbackGeneration;
 
     private float markPosition;
 
@@ -106,35 +108,11 @@ public class AudioPanel extends JPanel implements UIReloadable {
         panelState = PanelState.IDLE;
         playbackPosition = 0f;
         markPosition = 0f;
+        currentRequestId = 0L;
+        activePlaybackRequestId = 0L;
+        playbackGeneration = 0L;
         trackInfo = new VisualizationTrackInfo();
         trackInfo.reset();
-        playbackListener = new PlaybackListener() {
-            @Override
-            public void started() {
-            }
-
-            @Override
-            public void stopped(PlaybackThread.StopReason stopReason) {
-                // If we stopped because we ran out of audio data, hit next()
-                if (panelState == PanelState.PLAYING && stopReason != PlaybackThread.StopReason.INTERRUPTED) {
-                    next();
-                }
-            }
-
-            @Override
-            public boolean updateProgress(long curMillis, long totalMillis) {
-                if (audioData == null) {
-                    return false;
-                }
-                setPlaybackPosition((float) curMillis / (float) totalMillis);
-                trackInfo.setSourceFile(audioData.getSourceFile());
-                trackInfo.setCurrentTimeSeconds((int) (curMillis / 1000));
-                trackInfo.setTotalTimeSeconds(audioData.getDurationSeconds());
-                VisualizationWindow.getInstance().setTrackInfo(trackInfo);
-                return true;
-            }
-
-        };
         panelListeners = new ArrayList<>();
 
         // Lay out the UI:
@@ -184,9 +162,34 @@ public class AudioPanel extends JPanel implements UIReloadable {
     }
 
     public void setAudioData(AudioData data) {
+        if (data == null) {
+            currentRequestId = 0L;
+        }
+        setAudioDataInternal(data);
+    }
+
+    public boolean applyLoadedAudioData(long requestId, AudioData data) {
+        if (!AudioLoadCoordinator.getInstance().isCurrentRequest(requestId)) {
+            return false;
+        }
+
+        setAudioDataInternal(data);
+        currentRequestId = requestId;
+        return true;
+    }
+
+    public void playRequest(long requestId) {
+        if (audioData == null || currentRequestId != requestId || !AudioLoadCoordinator.getInstance().isCurrentRequest(requestId)) {
+            return;
+        }
+
+        play();
+    }
+
+    private void setAudioDataInternal(AudioData data) {
         // If we already had data, make sure we're stopped:
         if (audioData != null || panelState != PanelState.IDLE) {
-            stop();
+            stop(false);
             audioData = null;
             trackInfo.reset();
         }
@@ -253,7 +256,7 @@ public class AudioPanel extends JPanel implements UIReloadable {
             startOffset = (long) (markPosition * (audioData.getRawData()[0].length / (audioData.getSampleRate() / 1000)));
         }
 
-        internalPlay(startOffset);
+        internalPlay(currentRequestId, startOffset);
     }
 
     public void next() {
@@ -301,13 +304,15 @@ public class AudioPanel extends JPanel implements UIReloadable {
         // If we were already paused, treat this as "resume":
         if (panelState == PanelState.PAUSED) {
             long startOffset = (long) (markPosition * audioLength);
-            internalPlay(startOffset);
+            internalPlay(currentRequestId, startOffset);
             return;
         }
 
         // If we were playing, treat this as a "pause":
         if (panelState == PanelState.PLAYING) {
             panelState = PanelState.PAUSED;
+            playbackGeneration++;
+            activePlaybackRequestId = 0L;
             playbackThread.stop();
             markPosition = (float) playbackThread.getCurrentOffset() / audioLength;
             playbackThread = null;
@@ -321,10 +326,20 @@ public class AudioPanel extends JPanel implements UIReloadable {
      * if the control panel is visible and the user clicks it.
      */
     public void stop() {
+        stop(true);
+    }
+
+    private void stop(boolean cancelPendingLoads) {
         panelState = PanelState.IDLE;
+        playbackGeneration++;
+        activePlaybackRequestId = 0L;
         if (playbackThread != null) {
             playbackThread.stop();
             playbackThread = null;
+        }
+
+        if (cancelPendingLoads) {
+            AudioLoadCoordinator.getInstance().cancelPendingRequests();
         }
 
         VisualizationWindow.getInstance().setTrackInfo(null);
@@ -507,9 +522,15 @@ public class AudioPanel extends JPanel implements UIReloadable {
      * @param startOffset The offset from which to begin playing.
      */
     private void internalPlay(long startOffset) {
+        internalPlay(currentRequestId, startOffset);
+    }
+
+    private void internalPlay(long requestId, long startOffset) {
         try {
             panelState = PanelState.PLAYING;
-            playbackThread = AudioUtil.play(audioData, startOffset, playbackListener);
+            long generation = ++playbackGeneration;
+            activePlaybackRequestId = requestId;
+            playbackThread = AudioUtil.play(audioData, startOffset, createPlaybackListener(requestId, generation));
             fireStateChangedEvent();
         } catch (IOException | LineUnavailableException exc) {
             getMessageUtil().error("Playback error", "Problem playing audio: " + exc.getMessage(), exc);
@@ -517,6 +538,45 @@ public class AudioPanel extends JPanel implements UIReloadable {
             panelState = PanelState.IDLE;
             fireStateChangedEvent();
         }
+    }
+
+    private PlaybackListener createPlaybackListener(long requestId, long generation) {
+        return new PlaybackListener() {
+            @Override
+            public void started() {
+            }
+
+            @Override
+            public void stopped(PlaybackThread.StopReason stopReason) {
+                if (!isCurrentPlayback(requestId, generation)) {
+                    return;
+                }
+
+                // If we stopped because we ran out of audio data, hit next()
+                if (panelState == PanelState.PLAYING && stopReason != PlaybackThread.StopReason.INTERRUPTED) {
+                    next();
+                }
+            }
+
+            @Override
+            public boolean updateProgress(long curMillis, long totalMillis) {
+                if (!isCurrentPlayback(requestId, generation) || audioData == null) {
+                    return false;
+                }
+                setPlaybackPosition((float) curMillis / (float) totalMillis);
+                trackInfo.setSourceFile(audioData.getSourceFile());
+                trackInfo.setCurrentTimeSeconds((int) (curMillis / 1000));
+                trackInfo.setTotalTimeSeconds(audioData.getDurationSeconds());
+                VisualizationWindow.getInstance().setTrackInfo(trackInfo);
+                return true;
+            }
+        };
+    }
+
+    private boolean isCurrentPlayback(long requestId, long generation) {
+        return playbackGeneration == generation
+            && activePlaybackRequestId == requestId
+            && currentRequestId == requestId;
     }
 
     private MessageUtil getMessageUtil() {

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
@@ -56,9 +56,9 @@ public class AudioPanel extends JPanel implements UIReloadable {
     private PlaybackThread playbackThread;
     private float playbackPosition; // 0f==start, 1f==end
     private final VisualizationTrackInfo trackInfo;
-    private long currentRequestId;
-    private long activePlaybackRequestId;
-    private long playbackGeneration;
+    private volatile long currentRequestId;
+    private volatile long activePlaybackRequestId;
+    private volatile long playbackGeneration;
 
     private float markPosition;
 

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
@@ -11,6 +11,7 @@ import ca.corbett.musicplayer.audio.AudioUtil;
 
 import javax.sound.sampled.LineUnavailableException;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -253,7 +254,7 @@ public class AudioPanel extends JPanel implements UIReloadable {
         // Set starting offset if set:
         long startOffset = 0;
         if (markPosition > 0f) {
-            startOffset = (long) (markPosition * (audioData.getRawData()[0].length / (audioData.getSampleRate() / 1000)));
+            startOffset = positionToMillis(markPosition);
         }
 
         internalPlay(currentRequestId, startOffset);
@@ -296,14 +297,15 @@ public class AudioPanel extends JPanel implements UIReloadable {
     public void pause() {
         // Wonky case maybe, but let's avoid NullPointerExceptions if someone tries
         // to pause us when nothing is loaded:
-        if (audioData == null || audioData.getRawData() == null) {
+        if (audioData == null) {
             return;
         }
 
-        final float audioLength = audioData.getRawData()[0].length / (audioData.getSampleRate() / 1000f);
+        final long durationMillis = getDurationMillis();
+
         // If we were already paused, treat this as "resume":
         if (panelState == PanelState.PAUSED) {
-            long startOffset = (long) (markPosition * audioLength);
+            long startOffset = positionToMillis(markPosition);
             internalPlay(currentRequestId, startOffset);
             return;
         }
@@ -314,7 +316,7 @@ public class AudioPanel extends JPanel implements UIReloadable {
             playbackGeneration++;
             activePlaybackRequestId = 0L;
             playbackThread.stop();
-            markPosition = (float) playbackThread.getCurrentOffset() / audioLength;
+            markPosition = millisToPosition(playbackThread.getCurrentOffset(), durationMillis);
             playbackThread = null;
             redrawWaveform();
         }
@@ -548,14 +550,12 @@ public class AudioPanel extends JPanel implements UIReloadable {
 
             @Override
             public void stopped(PlaybackThread.StopReason stopReason) {
-                if (!isCurrentPlayback(requestId, generation)) {
-                    return;
-                }
-
-                // If we stopped because we ran out of audio data, hit next()
-                if (panelState == PanelState.PLAYING && stopReason != PlaybackThread.StopReason.INTERRUPTED) {
-                    next();
-                }
+                runIfCurrentOnEdt(requestId, generation, () -> {
+                    // If we stopped because we ran out of audio data, hit next()
+                    if (panelState == PanelState.PLAYING && stopReason != PlaybackThread.StopReason.INTERRUPTED) {
+                        next();
+                    }
+                });
             }
 
             @Override
@@ -563,14 +563,59 @@ public class AudioPanel extends JPanel implements UIReloadable {
                 if (!isCurrentPlayback(requestId, generation) || audioData == null) {
                     return false;
                 }
-                setPlaybackPosition((float) curMillis / (float) totalMillis);
-                trackInfo.setSourceFile(audioData.getSourceFile());
-                trackInfo.setCurrentTimeSeconds((int) (curMillis / 1000));
-                trackInfo.setTotalTimeSeconds(audioData.getDurationSeconds());
-                VisualizationWindow.getInstance().setTrackInfo(trackInfo);
+
+                long safeTotal = totalMillis > 0 ? totalMillis : getDurationMillis();
+                float pos = millisToPosition(curMillis, safeTotal);
+
+                runIfCurrentOnEdt(requestId, generation, () -> {
+                    setPlaybackPosition(pos);
+                    trackInfo.setSourceFile(audioData.getSourceFile());
+                    trackInfo.setCurrentTimeSeconds((int) (curMillis / 1000));
+                    trackInfo.setTotalTimeSeconds(audioData.getDurationSeconds());
+                    VisualizationWindow.getInstance().setTrackInfo(trackInfo);
+                });
                 return true;
             }
         };
+    }
+
+    private long getDurationMillis() {
+        if (audioData == null) {
+            return 1L;
+        }
+
+        int seconds = audioData.getDurationSeconds();
+        if (seconds <= 0 && audioData.getMetadata() != null) {
+            seconds = audioData.getMetadata().getDurationSeconds();
+        }
+        return Math.max(1L, seconds * 1000L);
+    }
+
+    private long positionToMillis(float pos) {
+        float clamped = Math.max(0f, Math.min(pos, 1f));
+        return (long) (clamped * getDurationMillis());
+    }
+
+    private float millisToPosition(long millis, long totalMillis) {
+        long safeTotal = Math.max(1L, totalMillis);
+        float raw = (float) millis / (float) safeTotal;
+        return Math.max(0f, Math.min(raw, 1f));
+    }
+
+    private void runIfCurrentOnEdt(long requestId, long generation, Runnable task) {
+        Runnable guardedTask = () -> {
+            if (!isCurrentPlayback(requestId, generation)) {
+                return;
+            }
+            task.run();
+        };
+
+        if (SwingUtilities.isEventDispatchThread()) {
+            guardedTask.run();
+        }
+        else {
+            SwingUtilities.invokeLater(guardedTask);
+        }
     }
 
     private boolean isCurrentPlayback(long requestId, long generation) {

--- a/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/AudioPanel.java
@@ -69,6 +69,8 @@ public class AudioPanel extends JPanel implements UIReloadable {
 
     private final ImagePanel imagePanel;
     private BufferedImage waveformImage;
+    private volatile boolean waveformRefreshInProgress;
+    private volatile boolean waveformRefreshPending;
 
     private final List<AudioPanelListener> panelListeners;
     private PanelState panelState;
@@ -115,6 +117,8 @@ public class AudioPanel extends JPanel implements UIReloadable {
         trackInfo = new VisualizationTrackInfo();
         trackInfo.reset();
         panelListeners = new ArrayList<>();
+        waveformRefreshInProgress = false;
+        waveformRefreshPending = false;
 
         // Lay out the UI:
         initComponents();
@@ -187,6 +191,43 @@ public class AudioPanel extends JPanel implements UIReloadable {
         play();
     }
 
+    public void refreshWaveformForRequest(long requestId) {
+        if (audioData == null || currentRequestId != requestId || !AudioLoadCoordinator.getInstance().isCurrentRequest(requestId)) {
+            return;
+        }
+
+        if (waveformRefreshInProgress) {
+            waveformRefreshPending = true;
+            return;
+        }
+
+        waveformRefreshInProgress = true;
+        waveformRefreshPending = false;
+        AudioData requestedData = audioData;
+        Thread worker = new Thread(() -> {
+            BufferedImage rendered = requestedData.generateWaveformImageSnapshot();
+            SwingUtilities.invokeLater(() -> {
+                try {
+                    if (audioData == requestedData
+                        && currentRequestId == requestId
+                        && AudioLoadCoordinator.getInstance().isCurrentRequest(requestId)) {
+                        waveformImage = rendered;
+                        redrawWaveform();
+                    }
+                }
+                finally {
+                    waveformRefreshInProgress = false;
+                    if (waveformRefreshPending) {
+                        waveformRefreshPending = false;
+                        refreshWaveformForRequest(requestId);
+                    }
+                }
+            });
+        }, "musicplayer-waveform-refresh");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
     private void setAudioDataInternal(AudioData data) {
         // If we already had data, make sure we're stopped:
         if (audioData != null || panelState != PanelState.IDLE) {
@@ -197,6 +238,8 @@ public class AudioPanel extends JPanel implements UIReloadable {
 
         // If the new data is null, switch on the idle animation:
         if (data == null) {
+            waveformRefreshInProgress = false;
+            waveformRefreshPending = false;
             AudioPanelIdleAnimation.getInstance().go();
             return;
         }

--- a/src/main/java/ca/corbett/musicplayer/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/MainWindow.java
@@ -358,6 +358,7 @@ public class MainWindow extends JFrame implements UIReloadable, AudioPanelListen
     private static void cleanup() {
         MainWindow.getInstance().keyStrokeManager.dispose();
         new StopAction().actionPerformed(null);
+        AudioLoadCoordinator.getInstance().shutdown();
         try {
             // If we're already on the UI thread, we can just stop fullscreen mode directly:
             if (SwingUtilities.isEventDispatchThread()) {

--- a/src/main/java/ca/corbett/musicplayer/ui/Playlist.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/Playlist.java
@@ -1,7 +1,6 @@
 package ca.corbett.musicplayer.ui;
 
 import ca.corbett.extras.MessageUtil;
-import ca.corbett.extras.progress.MultiProgressDialog;
 import ca.corbett.musicplayer.Actions;
 import ca.corbett.musicplayer.AppConfig;
 import ca.corbett.musicplayer.actions.PlaylistSortAction;
@@ -496,7 +495,7 @@ public class Playlist extends JPanel implements UIReloadable {
         // Select and play:
         fileList.setSelectedIndex(index);
         AudioPanel.getInstance().setAudioData(null); // force an unload of whatever was loaded
-        AudioPanel.getInstance().play(); // will force a load of the selected track
+        loadSelected();
     }
 
     /**
@@ -559,11 +558,13 @@ public class Playlist extends JPanel implements UIReloadable {
     /**
      * Loads audio data for whatever is currently selected in the playlist.
      * If the playlist is empty or nothing is selected, nothing happens.
-     * The load will be done in a worker thread with a progress dialog,
-     * so this method returns immediately while the data is still being
-     * loaded. Upon completion, the resulting AudioData will be loaded
-     * into the AudioPanel by the worker thread. If something goes wrong,
-     * an error is logged and displayed to the user and nothing is loaded.
+     * The load is submitted to AudioLoadCoordinator, which serializes
+     * requests in the background and only allows the latest request to
+     * affect the UI. This method returns immediately while the data is
+     * still being loaded. Upon completion, the resulting AudioData will
+     * be loaded into the AudioPanel automatically, unless the request
+     * has since gone stale. If something goes wrong, an error is logged
+     * and displayed to the user and nothing is loaded.
      */
     public void loadSelected() {
         AudioMetadata selectedMeta = fileList.getSelectedValue();
@@ -573,9 +574,7 @@ public class Playlist extends JPanel implements UIReloadable {
             return;
         }
 
-        MultiProgressDialog progress = new MultiProgressDialog(MainWindow.getInstance(), "Loading audio data...");
-        progress.setInitialShowDelayMS(AppConfig.getInstance().getLoadProgressBarShowDelayMS());
-        progress.runWorker(new AudioLoadThread(selected), true);
+        AudioLoadCoordinator.getInstance().requestLoad(selected);
     }
 
     protected void initComponents() {
@@ -852,8 +851,7 @@ public class Playlist extends JPanel implements UIReloadable {
             // If it's a double click and something is selected, force a load and play:
             // (this is a bit wonky if you double-click whatever's currently playing, but okay):
             if (e.getClickCount() == 2 && Playlist.getInstance().fileList.getSelectedIndex() != -1) {
-                AudioPanel.getInstance().setAudioData(null);
-                AudioPanel.getInstance().play();
+                Playlist.getInstance().selectAndPlay(Playlist.getInstance().fileList.getSelectedIndex());
             }
         }
     }

--- a/src/main/java/ca/corbett/musicplayer/ui/WaveformBuildThread.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/WaveformBuildThread.java
@@ -1,0 +1,96 @@
+package ca.corbett.musicplayer.ui;
+
+import ca.corbett.musicplayer.audio.AudioUtil;
+import ca.corbett.musicplayer.audio.WaveformPeaks;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.function.BooleanSupplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Background worker that decodes source audio into compact waveform peaks.
+ */
+public class WaveformBuildThread extends Thread {
+
+    private static final Logger logger = Logger.getLogger(WaveformBuildThread.class.getName());
+
+    private final File sourceFile;
+    private final WaveformPeaks peaks;
+    private final BooleanSupplier keepGoing;
+    private final Runnable onUpdate;
+
+    public WaveformBuildThread(File sourceFile, WaveformPeaks peaks, BooleanSupplier keepGoing, Runnable onUpdate) {
+        super("musicplayer-waveform-builder");
+        this.sourceFile = sourceFile;
+        this.peaks = peaks;
+        this.keepGoing = keepGoing == null ? () -> true : keepGoing;
+        this.onUpdate = onUpdate == null ? () -> { } : onUpdate;
+        setDaemon(true);
+        setPriority(Thread.MIN_PRIORITY);
+    }
+
+    @Override
+    public void run() {
+        if (sourceFile == null || peaks == null) {
+            return;
+        }
+
+        try (AudioInputStream stream = AudioUtil.openPlaybackStream(sourceFile)) {
+            AudioFormat format = stream.getFormat();
+            int channels = Math.max(1, format.getChannels());
+            int frameSize = Math.max(2, format.getFrameSize());
+            int framesPerBucket = Math.max(1, peaks.getFramesPerBucket());
+            byte[] buffer = new byte[frameSize * 2048];
+            short[] maxAbs = new short[channels];
+            int frameCount = 0;
+            int updateCounter = 0;
+
+            int bytesRead;
+            while ((bytesRead = stream.read(buffer)) > 0) {
+                if (!keepGoing.getAsBoolean() || Thread.currentThread().isInterrupted()) {
+                    return;
+                }
+
+                int frames = bytesRead / frameSize;
+                int idx = 0;
+                for (int f = 0; f < frames; f++) {
+                    for (int ch = 0; ch < channels; ch++) {
+                        int lo = buffer[idx++] & 0xff;
+                        int hi = buffer[idx++];
+                        short sample = (short) ((hi << 8) | lo);
+                        short abs = (short) Math.min(Short.MAX_VALUE, Math.abs(sample));
+                        if (abs > maxAbs[ch]) {
+                            maxAbs[ch] = abs;
+                        }
+                    }
+
+                    frameCount++;
+                    if (frameCount >= framesPerBucket) {
+                        peaks.addBucket(maxAbs);
+                        maxAbs = new short[channels];
+                        frameCount = 0;
+                        updateCounter++;
+                        if (updateCounter >= 24) {
+                            updateCounter = 0;
+                            onUpdate.run();
+                        }
+                    }
+                }
+            }
+
+            if (frameCount > 0) {
+                peaks.addBucket(maxAbs);
+            }
+            peaks.setComplete(true);
+            onUpdate.run();
+        }
+        catch (IOException ex) {
+            logger.log(Level.FINE, "Waveform build aborted for {0}: {1}", new Object[]{sourceFile.getName(), ex.getMessage()});
+        }
+    }
+}
+

--- a/src/main/java/ca/corbett/musicplayer/ui/WaveformBuildThread.java
+++ b/src/main/java/ca/corbett/musicplayer/ui/WaveformBuildThread.java
@@ -33,6 +33,43 @@ public class WaveformBuildThread extends Thread {
         setPriority(Thread.MIN_PRIORITY);
     }
 
+    private static int decodeSample(byte[] buffer, int offset, int bytesPerSample, boolean bigEndian, boolean signedPcm) {
+        int sample = 0;
+        if (bigEndian) {
+            for (int i = 0; i < bytesPerSample; i++) {
+                sample = (sample << 8) | (buffer[offset + i] & 0xff);
+            }
+        }
+        else {
+            for (int i = bytesPerSample - 1; i >= 0; i--) {
+                sample = (sample << 8) | (buffer[offset + i] & 0xff);
+            }
+        }
+
+        int bits = bytesPerSample * 8;
+        if (signedPcm) {
+            int signBit = 1 << (bits - 1);
+            if ((sample & signBit) != 0) {
+                sample -= 1 << bits;
+            }
+        }
+        else {
+            sample -= 1 << (bits - 1);
+        }
+        return sample;
+    }
+
+    private static short toPeakMagnitude(int sample, int sampleSizeInBits) {
+        long abs = Math.abs((long) sample);
+        if (sampleSizeInBits > 16) {
+            abs >>= (sampleSizeInBits - 16);
+        }
+        else if (sampleSizeInBits > 0 && sampleSizeInBits < 16) {
+            abs <<= (16 - sampleSizeInBits);
+        }
+        return (short) Math.min(Short.MAX_VALUE, abs);
+    }
+
     @Override
     public void run() {
         if (sourceFile == null || peaks == null) {
@@ -42,7 +79,11 @@ public class WaveformBuildThread extends Thread {
         try (AudioInputStream stream = AudioUtil.openPlaybackStream(sourceFile)) {
             AudioFormat format = stream.getFormat();
             int channels = Math.max(1, format.getChannels());
-            int frameSize = Math.max(2, format.getFrameSize());
+            int sampleSizeInBits = format.getSampleSizeInBits() > 0 ? format.getSampleSizeInBits() : 16;
+            int bytesPerSample = Math.max(1, (sampleSizeInBits + 7) / 8);
+            int frameSize = Math.max(bytesPerSample * channels, format.getFrameSize());
+            boolean bigEndian = format.isBigEndian();
+            boolean signedPcm = AudioFormat.Encoding.PCM_SIGNED.equals(format.getEncoding());
             int framesPerBucket = Math.max(1, peaks.getFramesPerBucket());
             byte[] buffer = new byte[frameSize * 2048];
             short[] maxAbs = new short[channels];
@@ -58,15 +99,16 @@ public class WaveformBuildThread extends Thread {
                 int frames = bytesRead / frameSize;
                 int idx = 0;
                 for (int f = 0; f < frames; f++) {
+                    int frameStart = idx;
                     for (int ch = 0; ch < channels; ch++) {
-                        int lo = buffer[idx++] & 0xff;
-                        int hi = buffer[idx++];
-                        short sample = (short) ((hi << 8) | lo);
-                        short abs = (short) Math.min(Short.MAX_VALUE, Math.abs(sample));
+                        int sample = decodeSample(buffer, idx, bytesPerSample, bigEndian, signedPcm);
+                        idx += bytesPerSample;
+                        short abs = toPeakMagnitude(sample, sampleSizeInBits);
                         if (abs > maxAbs[ch]) {
                             maxAbs[ch] = abs;
                         }
                     }
+                    idx = frameStart + frameSize;
 
                     frameCount++;
                     if (frameCount >= framesPerBucket) {

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -9,6 +9,7 @@ Version 3.3 [TODO release date goes here] - Maintenance release
   #88 Add playlist deletion keyboard shortcuts
   #87 AboutDialog was not showing application update information
   #64 Remove old code workaround for this issue (no longer needed)
+  #53 Rewrite audio load pipeline for better performance
 
 Version 3.2 [2025-12-31] - Maintenance release
   #84 SingleInstanceManager has moved to swing-extras 2.6

--- a/src/test/java/ca/corbett/musicplayer/ActionsTest.java
+++ b/src/test/java/ca/corbett/musicplayer/ActionsTest.java
@@ -86,7 +86,8 @@ class ActionsTest {
         @Override
         public List<Actions.MPAction> getMediaPlayerActions() {
             List<Actions.MPAction> list = new ArrayList<>();
-            list.add(new Actions.MPAction("TESTMP", "TESTMP", "", new AbstractAction() {
+            list.add(new Actions.MPAction("TESTMP", "TESTMP", "media-playback-stop.png",
+                                          new AbstractAction() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                 }
@@ -97,7 +98,8 @@ class ActionsTest {
         @Override
         public List<Actions.MPAction> getPlaylistActions() {
             List<Actions.MPAction> list = new ArrayList<>();
-            list.add(new Actions.MPAction("TESTPL", "TESTPL", "", new AbstractAction() {
+            list.add(new Actions.MPAction("TESTPL", "TESTPL", "media-playback-stop.png",
+                                          new AbstractAction() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                 }

--- a/src/test/java/ca/corbett/musicplayer/ui/AudioLoadCoordinatorTest.java
+++ b/src/test/java/ca/corbett/musicplayer/ui/AudioLoadCoordinatorTest.java
@@ -1,0 +1,216 @@
+package ca.corbett.musicplayer.ui;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AudioLoadCoordinatorTest {
+
+    private AudioLoadCoordinator coordinator;
+
+    @BeforeEach
+    void setUp() {
+        coordinator = AudioLoadCoordinator.getInstance();
+        // Cancel any pending requests to start each test from a clean, known state.
+        coordinator.cancelPendingRequests();
+    }
+
+    // -----------------------------------------------------------------------
+    // requestLoad: request ID management
+    // -----------------------------------------------------------------------
+
+    @Test
+    void requestLoad_withNullFile_shouldReturnCurrentIdUnchanged() {
+        // GIVEN an initial latest request id:
+        long before = coordinator.getLatestRequestId();
+
+        // WHEN we try to load a null file:
+        long returned = coordinator.requestLoad(null);
+
+        // THEN the returned id and the latest id should both be unchanged:
+        assertEquals(before, returned);
+        assertEquals(before, coordinator.getLatestRequestId());
+    }
+
+    @Test
+    void requestLoad_withValidFile_shouldReturnIncrementingId() {
+        // GIVEN the current latest id:
+        long before = coordinator.getLatestRequestId();
+
+        // WHEN we request a load (file need not exist for ID tracking):
+        long id1 = coordinator.requestLoad(new File("/nonexistent/track1.mp3"));
+        coordinator.cancelPendingRequests(); // prevent background processing
+
+        // THEN the returned id should be strictly greater than the previous one:
+        assertTrue(id1 > before, "requestLoad should return an id greater than the previous latest id");
+        // AND the latest request id should match the returned id before cancellation bumps it.
+    }
+
+    @Test
+    void requestLoad_withSequentialCalls_shouldReturnStrictlyIncreasingIds() {
+        // WHEN we issue multiple load requests:
+        long id1 = coordinator.requestLoad(new File("/nonexistent/a.mp3"));
+        long id2 = coordinator.requestLoad(new File("/nonexistent/b.mp3"));
+        long id3 = coordinator.requestLoad(new File("/nonexistent/c.mp3"));
+        coordinator.cancelPendingRequests(); // prevent background processing
+
+        // THEN each successive id should be strictly larger:
+        assertTrue(id2 > id1, "Second request id should be greater than first");
+        assertTrue(id3 > id2, "Third request id should be greater than second");
+    }
+
+    // -----------------------------------------------------------------------
+    // Only the latest request applies / stale requests are ignored
+    // -----------------------------------------------------------------------
+
+    @Test
+    void requestLoad_withMultipleRapidRequests_onlyLatestIsCurrent() {
+        // GIVEN three rapid load requests:
+        long id1 = coordinator.requestLoad(new File("/nonexistent/a.mp3"));
+        long id2 = coordinator.requestLoad(new File("/nonexistent/b.mp3"));
+        long id3 = coordinator.requestLoad(new File("/nonexistent/c.mp3"));
+        coordinator.cancelPendingRequests(); // prevent background processing
+
+        // THEN only the last id issued before cancellation was the latest at that point.
+        // id1 and id2 are stale relative to id3:
+        assertFalse(coordinator.isCurrentRequest(id1), "id1 should be stale after id2 and id3 were issued");
+        assertFalse(coordinator.isCurrentRequest(id2), "id2 should be stale after id3 was issued");
+        // After cancelPendingRequests() the counter is bumped so id3 is also stale:
+        assertFalse(coordinator.isCurrentRequest(id3), "id3 should be stale after cancelPendingRequests() bumps the counter");
+    }
+
+    @Test
+    void isCurrentRequest_withLatestId_shouldReturnTrue() {
+        // WHEN we queue a single request:
+        long id = coordinator.requestLoad(new File("/nonexistent/track.mp3"));
+
+        // THEN isCurrentRequest should return true for that id:
+        assertTrue(coordinator.isCurrentRequest(id), "The freshly issued id should be current");
+
+        coordinator.cancelPendingRequests(); // cleanup
+    }
+
+    @Test
+    void isCurrentRequest_withOlderIdAfterNewerRequest_shouldReturnFalse() {
+        // GIVEN a first request:
+        long staleId = coordinator.requestLoad(new File("/nonexistent/first.mp3"));
+
+        // WHEN a second request supersedes it:
+        long currentId = coordinator.requestLoad(new File("/nonexistent/second.mp3"));
+        coordinator.cancelPendingRequests(); // prevent background processing
+
+        // THEN only the most recent non-cancelled id was current just before cancellation.
+        // After cancel both are stale; the important thing is staleId != currentId:
+        assertNotEquals(staleId, currentId, "Successive requests should produce different ids");
+        assertFalse(coordinator.isCurrentRequest(staleId), "staleId should not be current after it was superseded");
+    }
+
+    @Test
+    void isCurrentRequest_withZeroId_shouldAlwaysReturnFalse() {
+        // THEN requestId == 0 is never a valid current request:
+        assertFalse(coordinator.isCurrentRequest(0), "id 0 should never be a current request");
+    }
+
+    @Test
+    void isCurrentRequest_withNegativeId_shouldAlwaysReturnFalse() {
+        assertFalse(coordinator.isCurrentRequest(-1), "Negative ids should never be current");
+    }
+
+    // -----------------------------------------------------------------------
+    // cancelPendingRequests: prevents stale results from applying
+    // -----------------------------------------------------------------------
+
+    @Test
+    void cancelPendingRequests_shouldInvalidateCurrentRequest() {
+        // GIVEN an active load request:
+        long id = coordinator.requestLoad(new File("/nonexistent/track.mp3"));
+        assertTrue(coordinator.isCurrentRequest(id), "id should be current before cancellation");
+
+        // WHEN we cancel:
+        coordinator.cancelPendingRequests();
+
+        // THEN the previously current id should now be stale:
+        assertFalse(coordinator.isCurrentRequest(id), "id should be stale after cancelPendingRequests()");
+    }
+
+    @Test
+    void cancelPendingRequests_withNoPendingRequest_shouldBeIdempotent() {
+        // WHEN cancel is called with no active requests (already clean from setUp):
+        long idBefore = coordinator.getLatestRequestId();
+        coordinator.cancelPendingRequests();
+        long idAfter = coordinator.getLatestRequestId();
+
+        // THEN the coordinator should still be in a valid (incremented) state:
+        assertTrue(idAfter > idBefore, "cancelPendingRequests should increment the id even with no pending request");
+    }
+
+    // -----------------------------------------------------------------------
+    // Waveform refresh throttling
+    // -----------------------------------------------------------------------
+
+    @Test
+    void isWaveformRefreshThrottled_initialState_shouldNotBeThrottled() {
+        // GIVEN the coordinator is freshly reset (cancelPendingRequests resets waveform state):
+        // THEN a non-forced refresh should NOT be throttled (no recent refresh, no queued refresh):
+        assertFalse(coordinator.isWaveformRefreshThrottled(false),
+                    "Waveform refresh should not be throttled in the initial state");
+    }
+
+    @Test
+    void isWaveformRefreshThrottled_whenRefreshQueuedFlag_shouldBeThrottled() {
+        // GIVEN the queued flag is set:
+        coordinator.setWaveformRefreshQueuedForTesting(true);
+
+        // THEN a non-forced refresh should be throttled:
+        assertTrue(coordinator.isWaveformRefreshThrottled(false),
+                   "Waveform refresh should be throttled when a refresh is already queued");
+
+        // Cleanup
+        coordinator.cancelPendingRequests();
+    }
+
+    @Test
+    void isWaveformRefreshThrottled_whenWithinThrottleInterval_shouldBeThrottled() {
+        // GIVEN the last UI refresh happened just now:
+        coordinator.setLastWaveformRefreshMillisForTesting(System.currentTimeMillis());
+
+        // THEN a non-forced refresh should be throttled (within the minimum interval):
+        assertTrue(coordinator.isWaveformRefreshThrottled(false),
+                   "Waveform refresh should be throttled when the last refresh was very recent");
+
+        // Cleanup
+        coordinator.cancelPendingRequests();
+    }
+
+    @Test
+    void isWaveformRefreshThrottled_whenIntervalElapsed_shouldNotBeThrottled() {
+        // GIVEN the last refresh happened long ago (simulate with timestamp 0):
+        coordinator.setLastWaveformRefreshMillisForTesting(0);
+        coordinator.setWaveformRefreshQueuedForTesting(false);
+
+        // THEN a non-forced refresh should not be throttled:
+        assertFalse(coordinator.isWaveformRefreshThrottled(false),
+                    "Waveform refresh should not be throttled after the throttle interval has elapsed");
+    }
+
+    @Test
+    void isWaveformRefreshThrottled_withForceRefresh_shouldNeverBeThrottled() {
+        // GIVEN the most aggressive throttle conditions (very recent refresh + queued):
+        coordinator.setLastWaveformRefreshMillisForTesting(System.currentTimeMillis());
+        coordinator.setWaveformRefreshQueuedForTesting(true);
+
+        // WHEN forceRefresh is true:
+        // THEN the refresh should NOT be throttled regardless:
+        assertFalse(coordinator.isWaveformRefreshThrottled(true),
+                    "A forced waveform refresh should never be throttled");
+
+        // Cleanup
+        coordinator.cancelPendingRequests();
+    }
+}


### PR DESCRIPTION
This PR addresses issue #53 by completely rewriting the audio load pipeline for better performance:

- we now have a serialized thread-safe load pipeline that only allows one load thread at a time. (this avoids problems caused by users hitting "next" or "prev" many times in rapid succession - only the most recent request matters).
- removed the old "loadProgressBarShowDelayMS" as no longer needed
- moved waveform image generation to its own thread with incremental updates (MUCH better for large audio files)
- updated javadocs and copilot instructions to explain the new pipeline.
- added maven surefire plugin to `pom.xml` to fix command-line test runs
- added special handling of monaural files to ensure that the waveform is properly symmetrical. (The old code handled this by accident, by only referring to data from the 0th audio array).
