### PR TITLE
Issue #110 - fix AppConfig startup issue, unnecessary UI reload

### DIFF
--- a/src/main/java/ca/corbett/musicplayer/AppConfig.java
+++ b/src/main/java/ca/corbett/musicplayer/AppConfig.java
@@ -183,9 +183,13 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
      */
     @Deprecated(since = "4.1")
     public void loadWithoutUIReload() {
-        eventsEnabled.set(false);
-        load();
-        eventsEnabled.set(true);
+        final boolean prevValue = eventsEnabled.getAndSet(false);
+        try {
+            load();
+        }
+        finally {
+            eventsEnabled.set(prevValue);
+        }
     }
 
     public static AppConfig getInstance() {

--- a/src/main/java/ca/corbett/musicplayer/AppConfig.java
+++ b/src/main/java/ca/corbett/musicplayer/AppConfig.java
@@ -35,6 +35,7 @@ import java.awt.Font;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 import static ca.corbett.musicplayer.ui.ControlPanel.ButtonSize;
@@ -74,6 +75,7 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
 
     private static AppConfig instance;
     public static final File PROPS_FILE;
+    private static final AtomicBoolean eventsEnabled = new AtomicBoolean(false);
 
     private ComboProperty<String> idleAnimation;
     private EnumProperty<ButtonSize> buttonSize;
@@ -132,6 +134,10 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
         // Debatable, but I prefer the "classic" style props dialog for this application
         // over the newer "action panel" style introduced in swing-extras 2.8:
         setDialogType(DialogType.Classic);
+
+        // Now that our initial load is complete, we can enable events, so that future
+        // load() calls will trigger a UI reload automatically.
+        eventsEnabled.set(true);
     }
 
     /**
@@ -162,14 +168,24 @@ public class AppConfig extends AppProperties<MusicPlayerExtension> {
     @Override
     public void load() {
         super.load();
-        ReloadUIAction.getInstance().actionPerformed(null);
+        if (eventsEnabled.get()) {
+            ReloadUIAction.getInstance().actionPerformed(null);
+        }
     }
 
     /**
-     * Basically only invoked once on app startup to kick things off.
+     * No longer used by application code, but can't be removed because it's public
+     * and might be used by some application extension. The next time we do a major
+     * version bump, we can revisit this, because all extensions will have to
+     * be rebuilt anyway.
+     *
+     * @deprecated This method may be removed in the next major release (5.0). Use load() instead.
      */
+    @Deprecated(since = "4.1")
     public void loadWithoutUIReload() {
-        super.load();
+        eventsEnabled.set(false);
+        load();
+        eventsEnabled.set(true);
     }
 
     public static AppConfig getInstance() {

--- a/src/main/java/ca/corbett/musicplayer/Main.java
+++ b/src/main/java/ca/corbett/musicplayer/Main.java
@@ -77,7 +77,12 @@ public class Main {
                    new Object[]{Version.INSTALL_DIR, Version.SETTINGS_DIR, Version.EXTENSIONS_DIR});
         checkJavaRuntime();
         LookAndFeelManager.installExtraLafs();
-        AppConfig.getInstance().loadWithoutUIReload();
+
+        // Instantiating AppConfig will also implicitly instantiate our ExtensionManager and
+        // load all application extensions. This is followed by a load of all our properties,
+        // both application properties and extension properties.
+        // All we need to do is call getInstance() here.
+        AppConfig.getInstance();
 
         SwingUtilities.invokeLater(() -> {
             LookAndFeelManager.switchLaf(FlatLightLaf.class.getName());

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -3,7 +3,7 @@ https://github.com/scorbo2/musicplayer
 Author: Steve Corbett
 
 Version 4.1 [2026-06-24] - Maintenance release
-  TODO release notes for 4.1 here
+  #110 - Sort out AppConfig startup process
 
 Version 4.0 [2026-04-14] - New audio load pipeline
   #99 Wire up a FallbackExceptionHandler


### PR DESCRIPTION
This PR addresses issue #110 by fixing an issue with AppConfig on startup. The old code would trigger a completely unnecessary UI reload on startup, despite a method called `loadWithoutUIReload()`. This fix properly gates UI reload behind a private static `eventsEnabled` flag, which is disabled on initial startup. After the initial load, this flag is enabled, so that anyone invoking `load()` will trigger a UI reload, as intended. 

This fix is purely to avoid a UI reload on initial load.

I want to remove the `loadWithoutUIReload()` method, but it was foolishly marked as public in AppConfig, so it might actually be used by some application extensions. I've flagged it as deprecated with a comment warning that it might get removed on the next major version bump.
