### PR TITLE
Issue #112 - upgrade to swing-extras 3.0 and migrate to Java 25

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="temurin-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/installer.props
+++ b/installer.props
@@ -19,6 +19,9 @@ OUTPUT_DIR=target
 # Extra memory settings like Xmx and Xms can be specified here:
 JAVA_MEM=
 
+# Suppress the unnamed module warning for Java 24+:
+EXTRA_JAVA_ARGS="--enable-native-access=ALL-UNNAMED"
+
 # The application jar file:
 JAR="target/musicplayer-${VERSION}.jar"
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/musicplayer/extensions/builtin/QuickLoadDialog.java
+++ b/src/main/java/ca/corbett/musicplayer/extensions/builtin/QuickLoadDialog.java
@@ -25,6 +25,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -39,9 +40,9 @@ import java.util.List;
 public class QuickLoadDialog extends JDialog {
 
     private static QuickLoadDialog instance;
-    private JFileChooser fileChooser;
-    private QuickLoadListModel playlistListModel;
-    private JList playlistList;
+    private final JFileChooser fileChooser;
+    private final QuickLoadListModel playlistListModel;
+    private JList<File> playlistList;
 
     public QuickLoadDialog() {
         super(MainWindow.getInstance(), true);
@@ -96,7 +97,7 @@ public class QuickLoadDialog extends JDialog {
                         "Can't read playlist", JOptionPane.ERROR_MESSAGE);
             }
             List<File> list = FileSystemUtil.findFiles(QuickLoadExtension.getQuickDir(), false, "mplist");
-            list.sort((one, two) -> one.getName().toLowerCase().compareTo(two.getName().toLowerCase()));
+            list.sort(Comparator.comparing(File::getName, String.CASE_INSENSITIVE_ORDER));
             for (File file : list) {
                 playlistListModel.add(file);
             }
@@ -116,7 +117,7 @@ public class QuickLoadDialog extends JDialog {
     private JPanel buildPlaylistSelectionPanel() {
         JPanel panel = new JPanel();
         panel.setLayout(new BorderLayout());
-        playlistList = new JList(playlistListModel);
+        playlistList = new JList<>(playlistListModel);
 
         // Add the key listener once:
         playlistList.addKeyListener(new KeyAdapter() {
@@ -145,25 +146,7 @@ public class QuickLoadDialog extends JDialog {
 
         });
 
-        playlistList.setCellRenderer(new ListCellRenderer() {
-            @Override
-            public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-                JLabel label = new JLabel();
-                label.setText(((File) value).getName().replace(".mplist", ""));
-                if (isSelected) {
-                    label.setBackground(list.getSelectionBackground());
-                    label.setForeground(list.getSelectionForeground());
-                } else {
-                    label.setBackground(list.getBackground());
-                    label.setForeground(list.getForeground());
-                }
-                label.setEnabled(list.isEnabled());
-                label.setFont(list.getFont().deriveFont(27f));
-                label.setOpaque(true);
-                return label;
-            }
-
-        });
+        playlistList.setCellRenderer(new PlaylistCellRenderer());
         playlistList.setFont(playlistList.getFont().deriveFont(18f));
         JScrollPane scrollPane = new JScrollPane(playlistList);
         panel.add(scrollPane, BorderLayout.CENTER);
@@ -189,15 +172,38 @@ public class QuickLoadDialog extends JDialog {
         panel.add(okButton);
         panel.add(cancelButton);
 
-        otherButton.addActionListener(e -> {
+        otherButton.addActionListener(_ -> {
             if (fileChooser.showOpenDialog(instance) == JFileChooser.APPROVE_OPTION) {
                 Playlist.getInstance().loadPlaylists(List.of(fileChooser.getSelectedFile()));
                 setVisible(false);
             }
         });
-        okButton.addActionListener(e -> openSelectedPlaylist());
-        cancelButton.addActionListener(e -> setVisible(false));
+        okButton.addActionListener(_ -> openSelectedPlaylist());
+        cancelButton.addActionListener(_ -> setVisible(false));
 
         return panel;
+    }
+
+    private static class PlaylistCellRenderer implements ListCellRenderer<File> {
+
+        @Override
+        public Component getListCellRendererComponent(JList<? extends File> list, File value, int index, boolean isSelected, boolean cellHasFocus) {
+            JLabel label = new JLabel();
+            String safeName = value == null ? "(null)" : value.getName();
+            label.setText(safeName.replace(".mplist", ""));
+            if (isSelected) {
+                label.setBackground(list.getSelectionBackground());
+                label.setForeground(list.getSelectionForeground());
+            }
+            else {
+                label.setBackground(list.getBackground());
+                label.setForeground(list.getForeground());
+            }
+            label.setEnabled(list.isEnabled());
+            label.setFont(list.getFont().deriveFont(27f));
+            label.setOpaque(true);
+            return label;
+        }
+
     }
 }

--- a/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/musicplayer/ReleaseNotes.txt
@@ -3,6 +3,7 @@ https://github.com/scorbo2/musicplayer
 Author: Steve Corbett
 
 Version 4.1 [2026-06-24] - Maintenance release
+  #112 - Upgrade to swing-extras 3.0 / Java 25
   #110 - Sort out AppConfig startup process
 
 Version 4.0 [2026-04-14] - New audio load pipeline


### PR DESCRIPTION
This PR addresses issue #112:

- upgrading to swing-extras `3.0` (latest stable release) to pick up numerous Windows-specific bug fixes.
- migrating to Java 25 (latest LTS).
- address a few compiler warnings in `QuickLoadDialog`.
- suppress the "unnamed module" warning on startup caused by third-party libraries (Sqlite).
